### PR TITLE
bugfix/indel primer start stop validation

### DIFF
--- a/src/modules/site/templates/tools/indel_primer/submit.html
+++ b/src/modules/site/templates/tools/indel_primer/submit.html
@@ -184,13 +184,14 @@ $(document).ready(function(){
 
 	set_position = function() {
 		// Sets browser position based on input
+    const MAX_DIFF = 1000000
 		browser = igv.getBrowser()
 		let chromosome = $("#chromosome").val().trim()
-		let start = $("#start").val().trim().replace(/,/g, '')
-		let end = $("#stop").val().trim().replace(/,/g, '')
-    let diff = (+end) - (+start)
-		if (diff > 1000000 || diff <= 0) {
-			end = +start + 1000000
+		let start = parseInt($("#start").val().trim().replace(/,/g, ''), 10)
+		let end = parseInt($("#stop").val().trim().replace(/,/g, ''), 10)
+    let diff = end - start
+		if (diff > MAX_DIFF || diff <= 0) {
+			end = +start + MAX_DIFF
 		}
 		browser.search(`${chromosome}:${start}-${end}`)
 	}


### PR DESCRIPTION
Fixing pairwise_indel_finder set_position function to trim start and stop input values and replace commas, Adding a check for difference between start and stop input values and reset end to start +1000000 if diff is over 1000000 or less than or equal to 0