### PR TITLE
Change default checked boxes

### DIFF
--- a/src/modules/site/templates/data/vbrowser.html
+++ b/src/modules/site/templates/data/vbrowser.html
@@ -122,6 +122,10 @@ mark {
         </div>
       </form>
     </div> {# /col-list #}
+
+    <button class="btn nu-alt-btn btn-block" id="reset-cols-btn" onClick="select_default_columns()">
+      Reset Default Columns
+    </button>
   </div> {# /col-md-2 #}
 
   {# strain select list block #}
@@ -529,11 +533,22 @@ function init_data_table() {
 }
 
 
-/* Set all column checkboxes to their default values */
+/* Set all columns to their default visibility values */
 function select_default_columns() {
+
+  /* Set checkboxes */
   columnList.forEach((col, idx) => {
-    $( "#toggle_" + col.id ).attr("checked", col.default_visibility);
+    $( "#toggle_" + col.id ).prop("checked", col.default_visibility);
   });
+
+  /* Set table columns */
+  for (let i = 0; i < columnList.length; i++) {
+    const column = dTable.column(i);
+    column.visible(columnList[i].default_visibility);
+  }
+
+  /* Redraw the table */
+  dTable.columns.adjust().draw();
 }
 
 

--- a/src/modules/site/templates/data/vbrowser.html
+++ b/src/modules/site/templates/data/vbrowser.html
@@ -108,13 +108,13 @@ mark {
         <div class="form-group">
           <div class="select-checkbox">
             <div class="col-entry">
-              <input class="toggle-col-chk" type="checkbox" name="toggle_all_cols" id="toggle_all_cols" checked/> 
+              <input class="toggle-col-chk" type="checkbox" name="toggle_all_cols" id="toggle_all_cols"/>
               <strong><label id="toggle_all_cols_label" for="toggle_all_cols"> Select All </label> </strong>
             </div>
             <br>
           {% for col in columns %}
             <div class="col-entry">
-              <input class="toggle-col-chk" type="checkbox" name="toggle_{{ col['id'] }}" id="toggle_{{ col['id'] }}" data-column="{{ col['id'] }}" checked/> 
+              <input class="toggle-col-chk" type="checkbox" name="toggle_{{ col['id'] }}" id="toggle_{{ col['id'] }}" data-column="{{ col['id'] }}"/>
               <label for="toggle_{{ col['id'] }}"> {{ col['name'] }} </label>
             </div>
           {% endfor %}
@@ -163,14 +163,14 @@ mark {
 
           <div class="col-xs-6 form-group text-center">
             <div class="impact-entry select-checkbox">
-              <input class="toggle-impact-chk" type="checkbox" name="impact_high" id="impact_high" checked/> 
+              <input class="toggle-impact-chk" type="checkbox" name="impact_high" id="impact_high" checked/>
               <strong><label id="impact_high_label" for="impact_high"> High </label> </strong>
             </div>
           </div> {# /form group #}
 
           <div class="col-xs-6 form-group text-center">
             <div class="impact-entry select-checkbox">
-              <input class="toggle-impact-chk" type="checkbox" name="impact_low" id="impact_low" checked/> 
+              <input class="toggle-impact-chk" type="checkbox" name="impact_low" id="impact_low"/>
               <strong><label id="impact_low_label" for="impact_low"> Low </label> </strong>
             </div>
           </div> {# /form group #}
@@ -503,7 +503,8 @@ function init_data_table() {
     return { 
       "name": col.id, 
       "render": render,
-      "targets": idx
+      "targets": idx,
+      "visible": col['default_visibility'],
     } 
   });
 
@@ -528,12 +529,22 @@ function init_data_table() {
 }
 
 
+/* Set all column checkboxes to their default values */
+function select_default_columns() {
+  columnList.forEach((col, idx) => {
+    $( "#toggle_" + col.id ).attr("checked", col.default_visibility);
+  });
+}
+
+
 $(document).ready(function() {
 
   (function($) {
 
     init_selected_strain_set();
     init_data_table();
+
+    select_default_columns();
     
     const csrf_token = "{{ form.csrf_token._value() }}";
 

--- a/src/pkg/caendr/caendr/models/sql/strain_annotated_variant.py
+++ b/src/pkg/caendr/caendr/models/sql/strain_annotated_variant.py
@@ -65,8 +65,32 @@ class StrainAnnotatedVariant(DictSerializable, db.Model):
       {'id': 'divergent', 'name': 'Divergent'},
       {'id': 'release', 'name': 'Release Date'}
     ]
-    
-    
+
+
+  @staticmethod
+  def column_default_visibility(col):
+    """
+    Determine whether a column should be visible by default.
+
+    Takes column object with 'id' field.
+
+    Currently, this is based on a hard-coded list.  This can be changed to any desired filter.
+    """
+
+    default_list = [
+      "pos",
+      "consequence",
+      "amino_acid_change",
+      "strains",
+      "blosum",
+      "grantham",
+      "variant_impact",
+      "divergent"
+    ]
+
+    return col['id'] in default_list
+
+
   @classmethod
   def generate_interval_sql(cls, interval):
     interval = interval.replace(',','')

--- a/src/pkg/caendr/caendr/models/sql/strain_annotated_variant.py
+++ b/src/pkg/caendr/caendr/models/sql/strain_annotated_variant.py
@@ -34,6 +34,19 @@ class StrainAnnotatedVariant(DictSerializable, db.Model):
 
   __tablename__ = 'strain_annotated_variants'
   __gene_summary__ = db.relationship("WormbaseGeneSummary", backref='strain_annotated_variants', lazy='joined')
+
+
+  # List of columns to be checked by default
+  _column_default_list = [
+    "pos",
+    "consequence",
+    "amino_acid_change",
+    "strains",
+    "blosum",
+    "grantham",
+    "variant_impact",
+    "divergent"
+  ]
   
   
   def __repr__(self):
@@ -77,18 +90,7 @@ class StrainAnnotatedVariant(DictSerializable, db.Model):
     Currently, this is based on a hard-coded list.  This can be changed to any desired filter.
     """
 
-    default_list = [
-      "pos",
-      "consequence",
-      "amino_acid_change",
-      "strains",
-      "blosum",
-      "grantham",
-      "variant_impact",
-      "divergent"
-    ]
-
-    return col['id'] in default_list
+    return col['id'] in StrainAnnotatedVariant._column_default_list
 
 
   @classmethod
@@ -139,3 +141,10 @@ class StrainAnnotatedVariant(DictSerializable, db.Model):
     except ValueError:
       result = {}
     return result
+
+
+
+_full_column_list = list(map( lambda x: x['id'], StrainAnnotatedVariant.get_column_details() ))
+
+for col_id in StrainAnnotatedVariant._column_default_list:
+  assert col_id in _full_column_list, f'Could not set column ID "{col_id}" to checked by default - ID was not found. Is this a typo?'


### PR DESCRIPTION
Set certain checkboxes in Variant Browser to be checked by default.

List is defined in `StrainAnnotatedVariant` class, but could be set up to come from anywhere (cache, user preferences, etc).

Also included a "reset to default" button (see screenshot below).  I'm not sure about the styling / placement of this button, but I wanted to include the functionality on the page in some way.

<img width="459" alt="Screen Shot 2022-09-30 at 11 29 48 AM" src="https://user-images.githubusercontent.com/22177771/193317586-2cf50930-d9e6-414c-aae4-3e5faaa9edb5.png">