### PR TITLE
Adding __version__ dunder to the caendr pkg  and bumping the pkg version.

### DIFF
--- a/src/pkg/caendr/caendr/__init__.py
+++ b/src/pkg/caendr/caendr/__init__.py
@@ -1,0 +1,2 @@
+import pkg_resources 
+__version__ = pkg_resources.require("caendr")[0].version

--- a/src/pkg/caendr/setup.py
+++ b/src/pkg/caendr/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
   name='caendr',
-  version='1.0.0',
+  version='1.0.1',
   packages=['caendr'],
   install_requires=[
     'cachelib',


### PR DESCRIPTION
Adding the dunder attribute __version__ for the caendr package. Bumping the caendr package version to 1.0.1