### PR TITLE
New Data Release Structure

### DIFF
--- a/src/modules/site-v2/base/forms/forms.py
+++ b/src/modules/site-v2/base/forms/forms.py
@@ -29,14 +29,14 @@ from wtforms.validators import (Required,
 from wtforms.fields.html5 import EmailField
 
 
-from constants import PRICES, SECTOR_OPTIONS, SHIPPING_OPTIONS, PAYMENT_OPTIONS, REPORT_TYPES
+from constants import PRICES, SECTOR_OPTIONS, SHIPPING_OPTIONS, PAYMENT_OPTIONS
 
 from caendr.services.profile import get_profile_role_form_options
 from caendr.services.user import get_user_role_form_options, get_local_user_by_email
 from caendr.services.database_operation import get_db_op_form_options
 from caendr.services.indel_primer import get_indel_primer_chrom_choices
 from caendr.services.markdown import get_content_type_form_options
-from caendr.models.datastore import User, SPECIES_LIST
+from caendr.models.datastore import User, SPECIES_LIST, DatasetRelease
 from caendr.api.strain import query_strains
 from base.forms.validators import (validate_duplicate_strain, 
                                    validate_duplicate_isotype, 
@@ -196,6 +196,7 @@ class AdminEditToolContainerVersion(FlaskForm):
   
 class DatasetReleaseForm(FlaskForm):
   """ A form for creating a data release """
+  REPORT_TYPES = [(report_type.name, report_type.name) for report_type in DatasetRelease.all_report_types]
   version = IntegerField('Dataset Release Version', validators=[Required(message="Dataset release version (as an integer) is required (ex: 20210121)")])
   wormbase_version = IntegerField('Wormbase Version WS:', validators=[Required(message="Wormbase version (as an integer) is required (ex: WS276 -> 276)")])
   report_type = SelectField('Report Type', choices=REPORT_TYPES, validators=[Required()])

--- a/src/modules/site-v2/base/views/data/releases.py
+++ b/src/modules/site-v2/base/views/data/releases.py
@@ -134,25 +134,30 @@ def alignment_data(species, release_version=None):
 
   # Look up the species and release version
   try:
-    species, RELEASES, RELEASE = interpret_url_vars(species, release_version)
+    species, releases, release = interpret_url_vars(species, release_version)
 
   # If either could not be found, return an error page
   except NotFoundError:
     return abort(404)
 
   # Pre-2020 releases don't have data organized the same way
-  if RELEASE.report_type == 'V1':
-    return 
+  # TODO: Error page? Redirect to main release page?
+  if release.report_type == 'V1':
+    return
   
   # Post-2020 releases
-  title = "Alignment Data"
-  alt_parent_breadcrumb = {"title": "Data", "url": url_for('data.data')}
-  strain_listing = query_strains(release_version=release_version)
-  '''
-  DATASET_RELEASE, WORMBASE_VERSION = list(filter(lambda x: x[0] == release_version, RELEASES))[0]
-  REPORTS = ["alignment"]
-  '''
-  return render_template('data/alignment.html', **locals())
+  return render_template('data/alignment.html', **{
+    'title': "Alignment Data",
+    'alt_parent_breadcrumb': {"title": "Data", "url": url_for('data.data')},
+
+    'species':  species,
+    'RELEASE':  release,
+    'RELEASES': releases,
+
+    'strain_listing': query_strains(release_version=release_version),
+  })
+  # DATASET_RELEASE, WORMBASE_VERSION = list(filter(lambda x: x[0] == release_version, RELEASES))[0]
+  # REPORTS = ["alignment"]
 
 
 
@@ -164,24 +169,29 @@ def alignment_data(species, release_version=None):
 @cache.memoize(60*60)
 def strain_issues(species, release_version=None):
   """
-      Strain Issues page
+    Strain Issues page
+    Lists all strains with known issues for a given species & release.
   """
 
-  # Look up the species and release version
+  # Look up the species and release version, returning error page if either could not be found
   try:
-    species, RELEASES, RELEASE = interpret_url_vars(species, release_version)
-
-  # If either could not be found, return an error page
+    species, releases, release = interpret_url_vars(species, release_version)
   except NotFoundError:
     return abort(404)
 
   # Pre-2020 releases don't have data organized the same way
-  if RELEASE.report_type == 'V1':
-    return 
-  
-  # Post-2020 releases
-  title = "Strain Issues"
-  alt_parent_breadcrumb = {"title": "Data", "url": url_for('data.data')}
-  strain_listing_issues = query_strains(release_version=release_version, issues=True)
+  # TODO: Error page? Redirect to main release page?
+  if release.report_type == 'V1':
+    return
 
-  return render_template('strain/issues.html', **locals())
+  # Post-2020 releases
+  return render_template('strain/issues.html', **{
+    'title': "Strain Issues",
+    'alt_parent_breadcrumb': {"title": "Data", "url": url_for('data.data')},
+
+    'species':  species,
+    'RELEASE':  release,
+    'RELEASES': releases,
+
+    'strain_listing_issues': query_strains(release_version=release_version, issues=True),
+  })

--- a/src/modules/site-v2/base/views/data/releases.py
+++ b/src/modules/site-v2/base/views/data/releases.py
@@ -148,13 +148,14 @@ def alignment_data(species, release_version=None):
   # Post-2020 releases
   return render_template('data/alignment.html', **{
     'title': "Alignment Data",
+    'subtitle': species.short_name,
     'alt_parent_breadcrumb': {"title": "Data", "url": url_for('data.data')},
 
     'species':  species,
     'RELEASE':  release,
     'RELEASES': releases,
 
-    'strain_listing': query_strains(release_version=release_version),
+    'strain_listing': query_strains(release_version=release_version, species=species.name),
   })
   # DATASET_RELEASE, WORMBASE_VERSION = list(filter(lambda x: x[0] == release_version, RELEASES))[0]
   # REPORTS = ["alignment"]
@@ -187,11 +188,12 @@ def strain_issues(species, release_version=None):
   # Post-2020 releases
   return render_template('strain/issues.html', **{
     'title': "Strain Issues",
+    'subtitle': species.short_name,
     'alt_parent_breadcrumb': {"title": "Data", "url": url_for('data.data')},
 
     'species':  species,
     'RELEASE':  release,
     'RELEASES': releases,
 
-    'strain_listing_issues': query_strains(release_version=release_version, issues=True),
+    'strain_listing_issues': query_strains(release_version=release_version, species=species.name, issues=True),
   })

--- a/src/modules/site-v2/base/views/data/releases.py
+++ b/src/modules/site-v2/base/views/data/releases.py
@@ -52,7 +52,7 @@ def data_releases(release_version=None):
         RELEASE = r
         break
     if not RELEASE:
-      raise NotFoundError(f'Release Version: {release_version} Not Found')
+      raise NotFoundError(DatasetRelease, {'version': release_version})
   else:
     RELEASE = RELEASES[0]
   
@@ -121,7 +121,7 @@ def alignment_data(release_version=''):
         RELEASE = r
         break
     if not RELEASE:
-      raise NotFoundError(f'Release Version: {release_version} Not Found')
+      raise NotFoundError(DatasetRelease, {'version': release_version})
   else:
     RELEASE = RELEASES[0]
 
@@ -161,7 +161,7 @@ def strain_issues(release_version=None):
         RELEASE = r
         break
     if not RELEASE:
-      raise NotFoundError(f'Release Version: {release_version} Not Found')
+      raise NotFoundError(DatasetRelease, {'version': release_version})
   else:
     RELEASE = RELEASES[0]
 

--- a/src/modules/site-v2/base/views/data/releases.py
+++ b/src/modules/site-v2/base/views/data/releases.py
@@ -87,9 +87,9 @@ def data_release_list(species, release_version=None):
   files = release.get_report_data_urls_map(species.name[2:])
 
   # Update params object with version-specific fields
-  if release.report_type == 'V2':
+  if release.report_type == DatasetRelease.V2:
     params.update(data_v02(params, files))
-  elif release.report_type == 'V1':
+  elif release.report_type == DatasetRelease.V1:
     params.update(data_v01(params, files))
 
   # Render the page
@@ -154,9 +154,9 @@ def alignment_data(species, release_version=None):
 
   # Pre-2020 releases don't have data organized the same way
   # TODO: Error page? Redirect to main release page?
-  if release.report_type == 'V1':
+  if release.report_type == DatasetRelease.V1:
     return
-  
+
   # Post-2020 releases
   return render_template('data/alignment.html', **{
     'title': "Alignment Data",
@@ -194,7 +194,7 @@ def strain_issues(species, release_version=None):
 
   # Pre-2020 releases don't have data organized the same way
   # TODO: Error page? Redirect to main release page?
-  if release.report_type == 'V1':
+  if release.report_type == DatasetRelease.V1:
     return
 
   # Post-2020 releases

--- a/src/modules/site-v2/base/views/tools/genome_browser.py
+++ b/src/modules/site-v2/base/views/tools/genome_browser.py
@@ -104,7 +104,7 @@ def genome_browser(region="III:11746923-11750250", query=None):
     'default_tracks': sorted(BrowserTrackDefault.query_ds_visible(), key = lambda x: x['order'] ),
 
     # Data locations
-    'fasta_url': BrowserTrack.get_fasta_path_full(),
+    'fasta_url': BrowserTrack.get_fasta_path_full().get_string_safe(),
 
     # String replacement tokens
     # Maps token to the field in Species object it should be replaced with

--- a/src/modules/site-v2/base/views/tools/pairwise_indel_finder.py
+++ b/src/modules/site-v2/base/views/tools/pairwise_indel_finder.py
@@ -14,7 +14,6 @@ from base.forms import PairwiseIndelForm
 from caendr.models.datastore.browser_track import BrowserTrack, BrowserTrackDefault
 from caendr.models.datastore import SPECIES_LIST
 from caendr.models.error import NotFoundError, NonUniqueEntity
-from caendr.services.dataset_release import get_browser_tracks_path
 from caendr.utils.constants import CHROM_NUMERIC
 
 from caendr.services.indel_primer import get_sv_strains, query_indels_and_mark_overlaps, create_new_indel_primer, get_indel_primer, fetch_ip_data, fetch_ip_result, get_all_indel_primers, get_user_indel_primers
@@ -82,7 +81,7 @@ def pairwise_indel_finder():
     "species_list": SPECIES_LIST,
 
     # Data locations
-    "fasta_url": BrowserTrack.get_fasta_path_full(),
+    "fasta_url": BrowserTrack.get_fasta_path_full().get_string_safe(),
 
     # List of Species class fields to expose to the template
     # Optional - exposes all attributes if not provided

--- a/src/modules/site-v2/base/views/tools/pairwise_indel_finder.py
+++ b/src/modules/site-v2/base/views/tools/pairwise_indel_finder.py
@@ -40,7 +40,6 @@ def get_tracks():
 
   # If no track found, log an error message and continue raising with a more descriptive message
   except NotFoundError as ex:
-    ex.description = 'Could not find Divergent Regions track.'
     logger.error(ex.description)
     raise ex
 

--- a/src/modules/site-v2/constants.py
+++ b/src/modules/site-v2/constants.py
@@ -29,8 +29,6 @@ TABLE_COLORS = {
   "HIGH": 'danger'
 }
 
-REPORT_TYPES = [('V2', 'V2'), ('V1', 'V1'), ('V0', 'V0')]
-
 # TODO: REMOVE THESE
 REPORT_V1_FILE_LIST = ['methods.md']
 REPORT_V2_FILE_LIST = ['alignment_report.html', 'concordance_report.html', 'gatk_report.html', 'methods.md', 'reads_mapped_by_strain.tsv', 'release_notes.md']

--- a/src/modules/site-v2/templates/admin/dataset/list.html
+++ b/src/modules/site-v2/templates/admin/dataset/list.html
@@ -28,7 +28,7 @@
         {% for dataset in datasets %}
           <tr>
             <td> {{ dataset['version'] }} </td>
-            <td> {{ dataset['report_type'] }} </td>
+            <td> {{ dataset['report_type'].name }} </td>
             <td> {{ dataset['wormbase_version'] }} </td>
             <td> {{ dataset['disabled'] }} </td>
             <td> {{ dataset['hidden'] }} </td>

--- a/src/modules/site-v2/templates/data/alignment.html
+++ b/src/modules/site-v2/templates/data/alignment.html
@@ -3,7 +3,7 @@
 {% block content %}
 
 <p>Bolded strains are isotype reference strains, and tabbed non-bold face strains are strains within an isotype group but not the isotype reference strain.</p>
-<p>Only strains with whole-genome sequencing data have BAM files for download. If you do not see a strain, check the <a href="{{ url_for('data_releases.strain_issues', selected_release = selected_release) }}">Strain Issues</a> page.
+<p>Only strains with whole-genome sequencing data have BAM files for download. If you do not see a strain, check the <a href="{{ url_for('data_releases.strain_issues', species = species.get_url_name(), selected_release = selected_release) }}">Strain Issues</a> page.
 Some strains have been flagged and removed from distribution and analysis pipelines for a variety of reasons.</p>
 
 {% include('releases/download_tab_strain_v2.html') %}

--- a/src/modules/site-v2/templates/data/releases.html
+++ b/src/modules/site-v2/templates/data/releases.html
@@ -25,7 +25,7 @@ body, html{
       <h3>Releases</h3>
       {% for RELEASE in RELEASES %}
         <li {% if RELEASE.version == release_version %} class="active btn-nu" {% endif %}>
-          <a {% if RELEASE.disabled %} href="#" {% else %} href="{{ url_for('data_releases.data_releases', release_version = RELEASE.version) }}" {% endif %}>{{ RELEASE.version }}</a>
+          <a {% if RELEASE.disabled %} href="#" {% else %} href="{{ url_for('data_releases.data_release_list', species = species.get_url_name(), release_version = RELEASE.version) }}" {% endif %}>{{ RELEASE.version }}</a>
         </li>
       {% endfor %}
     </ul>

--- a/src/modules/site-v2/templates/data/v2.html
+++ b/src/modules/site-v2/templates/data/v2.html
@@ -63,13 +63,13 @@
 
                   <tr>
                       <td><strong>Strain Issues</strong></td>
-                      <td>This <a href="{{ url_for('data_releases.strain_issues', release_version = release_version) }}">link</a> contains all strain issues for this release</td>
+                      <td>This <a href="{{ url_for('data_releases.strain_issues', species = species.get_url_name(), release_version = release_version) }}">link</a> contains all strain issues for this release</td>
                       <td></td>
                   </tr>
 
                   <tr>
                       <td><strong>Alignment Data</strong></td>
-                      <td>This <a href="{{ url_for('data_releases.alignment_data', release_version = release_version) }}">link</a> contains all alignment data as BAM or BAI files.</td>
+                      <td>This <a href="{{ url_for('data_releases.alignment_data', species = species.get_url_name(), release_version = release_version) }}">link</a> contains all alignment data as BAM or BAI files.</td>
                       <td></td>
                   </tr>
 

--- a/src/pkg/caendr/caendr/models/datastore/container.py
+++ b/src/pkg/caendr/caendr/models/datastore/container.py
@@ -56,10 +56,10 @@ class Container(Entity):
     else:
       if version is None:
         logger.error(f'Unable to find container "{name}".')
-        raise NotFoundError(f'Unable to find container "{name}".')
+        raise NotFoundError(Container, {'container_name': name})
       else:
         logger.error(f'Unable to find container "{name}" with version "{version}".')
-        raise NotFoundError(f'Unable to find container "{name}" with version "{version}".')
+        raise NotFoundError(Container, {'container_name': name, 'container_version': version})
 
 
   @classmethod

--- a/src/pkg/caendr/caendr/models/datastore/dataset_release.py
+++ b/src/pkg/caendr/caendr/models/datastore/dataset_release.py
@@ -99,7 +99,6 @@ class DatasetRelease(Entity):
 
 
 
-
   @classmethod
   def get_bucket_name(cls):
     return cls.__bucket_name
@@ -137,7 +136,7 @@ class DatasetRelease(Entity):
     url_map_filtered = {}
     for key, blob_name in release_files.items():
       blob_path = TokenizedString(f'{blob_prefix}/{blob_name}').get_string(**{
-        'ver': self['version'],
+        'RELEASE': self['version'],
         'SPECIES': species_name,
       })
 
@@ -150,53 +149,54 @@ class DatasetRelease(Entity):
   
 
   V2 = ReportType('V2', {
-    'release_notes': '$ver/release_notes.md',
-    'summary': '$ver/summary.md',
-    'methods': '$ver/methods.md',
-    'alignment_report': '$ver/alignment_report.html',
-    'gatk_report': '$ver/gatk_report.html',
-    'concordance_report': '$ver/concordance_report.html',
+    'release_notes':                     '$RELEASE/release_notes.md',
+    'summary':                           '$RELEASE/summary.md',
+    'methods':                           '$RELEASE/methods.md',
+    'alignment_report':                  '$RELEASE/alignment_report.html',
+    'gatk_report':                       '$RELEASE/gatk_report.html',
+    'concordance_report':                '$RELEASE/concordance_report.html',
 
-    'divergent_regions_strain_bed_gz': '$ver/divergent_regions_strain.$ver.bed.gz',
-    'divergent_regions_strain_bed': '$ver/divergent_regions_strain.$ver.bed',
+    'divergent_regions_strain_bed_gz':   '$RELEASE/divergent_regions_strain.$RELEASE.bed.gz',
+    'divergent_regions_strain_bed':      '$RELEASE/divergent_regions_strain.$RELEASE.bed',
 
-    'soft_filter_vcf_gz': '$ver/variation/WI.$ver.soft-filter.vcf.gz',
-    'soft_filter_vcf_gz_tbi': '$ver/variation/WI.$ver.soft-filter.vcf.gz.tbi',
-    'soft_filter_isotype_vcf_gz': '$ver/variation/WI.$ver.soft-filter.isotype.vcf.gz',
-    'soft_filter_isotype_vcf_gz_tbi': '$ver/variation/WI.$ver.soft-filter.isotype.vcf.gz.tbi',
-    'hard_filter_vcf_gz': '$ver/variation/WI.$ver.hard-filter.vcf.gz',
-    'hard_filter_vcf_gz_tbi': '$ver/variation/WI.$ver.hard-filter.vcf.gz.tbi',
-    'hard_filter_isotype_vcf_gz': '$ver/variation/WI.$ver.hard-filter.isotype.vcf.gz',
-    'hard_filter_isotype_vcf_gz_tbi': '$ver/variation/WI.$ver.hard-filter.isotype.vcf.gz.tbi',
-    'impute_isotype_vcf_gz': '$ver/variation/WI.$ver.impute.isotype.vcf.gz',
-    'impute_isotype_vcf_gz_tbi': '$ver/variation/WI.$ver.impute.isotype.vcf.gz.tbi',
+    'soft_filter_vcf_gz':                '$RELEASE/variation/WI.$RELEASE.soft-filter.vcf.gz',
+    'soft_filter_vcf_gz_tbi':            '$RELEASE/variation/WI.$RELEASE.soft-filter.vcf.gz.tbi',
+    'soft_filter_isotype_vcf_gz':        '$RELEASE/variation/WI.$RELEASE.soft-filter.isotype.vcf.gz',
+    'soft_filter_isotype_vcf_gz_tbi':    '$RELEASE/variation/WI.$RELEASE.soft-filter.isotype.vcf.gz.tbi',
+    'hard_filter_vcf_gz':                '$RELEASE/variation/WI.$RELEASE.hard-filter.vcf.gz',
+    'hard_filter_vcf_gz_tbi':            '$RELEASE/variation/WI.$RELEASE.hard-filter.vcf.gz.tbi',
+    'hard_filter_isotype_vcf_gz':        '$RELEASE/variation/WI.$RELEASE.hard-filter.isotype.vcf.gz',
+    'hard_filter_isotype_vcf_gz_tbi':    '$RELEASE/variation/WI.$RELEASE.hard-filter.isotype.vcf.gz.tbi',
+    'impute_isotype_vcf_gz':             '$RELEASE/variation/WI.$RELEASE.impute.isotype.vcf.gz',
+    'impute_isotype_vcf_gz_tbi':         '$RELEASE/variation/WI.$RELEASE.impute.isotype.vcf.gz.tbi',
 
-    'hard_filter_min4_tree': '$ver/tree/WI.$ver.hard-filter.min4.tree',
-    'hard_filter_min4_tree_pdf': '$ver/tree/WI.$ver.hard-filter.min4.tree.pdf',
-    'hard_filter_isotype_min4_tree': '$ver/tree/WI.$ver.hard-filter.isotype.min4.tree',
-    'hard_filter_isotype_min4_tree_pdf': '$ver/tree/WI.$ver.hard-filter.isotype.min4.tree.pdf',
+    'hard_filter_min4_tree':             '$RELEASE/tree/WI.$RELEASE.hard-filter.min4.tree',
+    'hard_filter_min4_tree_pdf':         '$RELEASE/tree/WI.$RELEASE.hard-filter.min4.tree.pdf',
+    'hard_filter_isotype_min4_tree':     '$RELEASE/tree/WI.$RELEASE.hard-filter.isotype.min4.tree',
+    'hard_filter_isotype_min4_tree_pdf': '$RELEASE/tree/WI.$RELEASE.hard-filter.isotype.min4.tree.pdf',
 
-    'haplotype_png': '$ver/haplotype/haplotype.png',
-    'haplotype_pdf': '$ver/haplotype/haplotype.pdf',
-    'sweep_pdf': '$ver/haplotype/sweep.pdf',
-    'sweep_summary_tsv': '$ver/haplotype/sweep_summary.tsv'
+    'haplotype_png':                     '$RELEASE/haplotype/haplotype.png',
+    'haplotype_pdf':                     '$RELEASE/haplotype/haplotype.pdf',
+    'sweep_pdf':                         '$RELEASE/haplotype/sweep.pdf',
+    'sweep_summary_tsv':                 '$RELEASE/haplotype/sweep_summary.tsv'
   }, cutoff_date=20200101)
 
   V1 = ReportType('V1', {
-    'summary': '$ver/summary.md',
-    'methods': '$ver/methods.md',
-    'haplotype_png_url': '$ver/haplotype/haplotype.png',
-    'haplotype_thumb_png_url': '$ver/haplotype/haplotype.thumb.png',
-    'tajima_d_png_url': '$ver/popgen/tajima_d.png',
-    'tajima_d_thumb_png_url': '$ver/popgen/tajima_d.thumb.png',
-    'genome_svg_url': '$ver/popgen/trees/genome.svg',
+    'summary':                 '$RELEASE/summary.md',
+    'methods':                 '$RELEASE/methods.md',
 
-    'soft_filter_vcf_gz': '$ver/variation/WI.$ver.soft-filter.vcf.gz',
-    'hard_filter_vcf_gz': '$ver/variation/WI.$ver.hard-filter.vcf.gz',
-    'impute_vcf_gz': '$ver/variation/WI.$ver.impute.vcf.gz',
+    'haplotype_png_url':       '$RELEASE/haplotype/haplotype.png',
+    'haplotype_thumb_png_url': '$RELEASE/haplotype/haplotype.thumb.png',
+    'tajima_d_png_url':        '$RELEASE/popgen/tajima_d.png',
+    'tajima_d_thumb_png_url':  '$RELEASE/popgen/tajima_d.thumb.png',
+    'genome_svg_url':          '$RELEASE/popgen/trees/genome.svg',
 
-    'vcf_summary_url': '$ver/multiqc_bcftools_stats.json',
-    'phylo_url': '$ver/popgen/trees/genome.pdf'
+    'soft_filter_vcf_gz':      '$RELEASE/variation/WI.$RELEASE.soft-filter.vcf.gz',
+    'hard_filter_vcf_gz':      '$RELEASE/variation/WI.$RELEASE.hard-filter.vcf.gz',
+    'impute_vcf_gz':           '$RELEASE/variation/WI.$RELEASE.impute.vcf.gz',
+
+    'vcf_summary_url':         '$RELEASE/multiqc_bcftools_stats.json',
+    'phylo_url':               '$RELEASE/popgen/trees/genome.pdf'
   })
 
   V0 = ReportType('V0', {})

--- a/src/pkg/caendr/caendr/models/datastore/entity.py
+++ b/src/pkg/caendr/caendr/models/datastore/entity.py
@@ -342,7 +342,7 @@ class Entity(object):
     # If no matching entities found, return None
     if len(matches) == 0:
       if required:
-        raise NotFoundError(f'Could not find {cls.kind} entity with "{key}" = "{val}".')
+        raise NotFoundError( cls.kind, {key: val} )
       else:
         return None
 

--- a/src/pkg/caendr/caendr/models/datastore/indel_primer.py
+++ b/src/pkg/caendr/caendr/models/datastore/indel_primer.py
@@ -1,7 +1,7 @@
 import os
 
 from caendr.services.logger import logger
-from caendr.utils.env import get_env_var, replace_species_tokens
+from caendr.utils.env import get_env_var
 
 from caendr.models.datastore import DataJobEntity
 
@@ -45,9 +45,9 @@ class IndelPrimer(DataJobEntity):
       raise ValueError('Please provide a release for Indel Primer source filename.')
 
     # Fill in template with vars
-    return replace_species_tokens(SOURCE_FILENAME, **{
-      'species': species,
-      'release': release,
+    return SOURCE_FILENAME.get_string(**{
+      'SPECIES': species,
+      'RELEASE': release,
     })
 
 

--- a/src/pkg/caendr/caendr/models/datastore/species.py
+++ b/src/pkg/caendr/caendr/models/datastore/species.py
@@ -2,12 +2,19 @@ from logzero import logger
 
 from caendr.models.datastore import Entity
 from caendr.models.datastore import WormbaseVersion, WormbaseProjectNumber
-from caendr.models.error import BadRequestError
+from caendr.models.error import BadRequestError, NotFoundError
 
 
 
 class Species(Entity):
     kind = 'species'
+
+    @staticmethod
+    def get(species_name):
+        if species_name in SPECIES_LIST:
+            return SPECIES_LIST[species_name]
+        raise NotFoundError(Species, {'name': species_name})
+
 
     @classmethod
     def get_props_set(cls):
@@ -94,6 +101,10 @@ class Species(Entity):
     def sva_ver(self, new_sva_ver: str):
         # TODO: validate -- looks like this should be the 8 digit date string
         self._sva_ver = new_sva_ver
+
+
+    def get_url_name(self):
+        return self.name.replace('_', '-')
 
 
 

--- a/src/pkg/caendr/caendr/models/error.py
+++ b/src/pkg/caendr/caendr/models/error.py
@@ -44,6 +44,19 @@ class BadRequestError(InternalError):
 
 class NotFoundError(InternalError):
   description = 'Not Found'
+  def __init__(self, lookup_class, params):
+    self.params = params
+
+    if lookup_class:
+      try:
+        self.kind = lookup_class.kind
+      except:
+        self.kind = lookup_class
+    else:
+      self.kind = 'object'
+
+    param_str = ', '.join([ f'"{key}" = "{val}"' for key, val in self.params.items() ])
+    self.description = f'Could not find {self.kind} where [{param_str}].'
 
 class CloudStorageUploadError(InternalError):
   description = "Error uploading a blob to cloud storage"

--- a/src/pkg/caendr/caendr/models/error.py
+++ b/src/pkg/caendr/caendr/models/error.py
@@ -143,3 +143,12 @@ class FileUploadError(InternalError):
   def __init__(self, description=None):
     if description is not None:
       self.description = description
+
+
+class InvalidTokenError(InternalError):
+  def __init__(self, token):
+    self.token = token
+    self.description = f'Invalid token name {token}'
+
+class MissingTokenError(InternalError):
+  description = 'Cannot get filled-in template until all tokens are defined'

--- a/src/pkg/caendr/caendr/models/error.py
+++ b/src/pkg/caendr/caendr/models/error.py
@@ -143,3 +143,7 @@ class FileUploadError(InternalError):
   def __init__(self, description=None):
     if description is not None:
       self.description = description
+
+class SpeciesUrlNameError(InternalError):
+  def __init__(self, species_name):
+    self.species_name = species_name

--- a/src/pkg/caendr/caendr/services/cloud/storage.py
+++ b/src/pkg/caendr/caendr/services/cloud/storage.py
@@ -64,7 +64,7 @@ def download_blob_to_file(bucket_name, blob_name, filename):
     blob.download_to_file(open(filename, 'wb'))
     return filename
   else:
-    raise NotFoundError()
+    raise NotFoundError('blob', {'bucket': bucket_name, 'name': blob_name})
 
 def upload_blob_from_file_object(bucket_name, file, blob_name):
   """Uploads a file to the bucket."""

--- a/src/pkg/caendr/caendr/services/dataset_release.py
+++ b/src/pkg/caendr/caendr/services/dataset_release.py
@@ -3,7 +3,7 @@ from caendr.services.logger import logger
 from caendr.services.cloud.datastore import query_ds_entities, get_ds_entity, delete_ds_entity_by_ref
 from caendr.models.datastore import DatasetRelease
 from caendr.models.sql import Strain
-from caendr.models.error import UnprocessableEntity, BadRequestError
+from caendr.models.error import UnprocessableEntity, BadRequestError, NotFoundError
 
 
 def get_release_bucket():
@@ -55,11 +55,33 @@ def get_dataset_release(version: str):
   return release
 
 
+def find_dataset_release(release_list, version=None):
+  '''
+    Choose the dataset release with a given version from a list of releases.
+    If no version provided, returns the top element.
+    If more than one matching version, returns the first one found.
+  '''
+
+  # If nothing provided in list, raise an error
+  if not len(release_list):
+    raise NotFoundError(DatasetRelease, {'version': version})
+
+  # If no version specified, return the top element by default
+  if not version:
+    return release_list[0]
+
+  # Look for the requested release
+  for r in release_list:
+    if r.version == version:
+      return r
+
+  # If release couldn't be found, raise an error
+  raise NotFoundError(DatasetRelease, {'version': version})
+
+
 def get_latest_dataset_release_version():
   releases = get_all_dataset_releases(order='-version')
-  if len(releases) > 0:
-    latest_release = releases[0]
-    return latest_release
+  return find_dataset_release(releases)
 
 
 def create_new_dataset_release(version: str, wormbase_version: str, report_type: str, disabled: bool=False, hidden: bool=False):

--- a/src/pkg/caendr/caendr/services/dataset_release.py
+++ b/src/pkg/caendr/caendr/services/dataset_release.py
@@ -2,6 +2,7 @@ from caendr.services.logger import logger
 
 from caendr.services.cloud.datastore import query_ds_entities, get_ds_entity, delete_ds_entity_by_ref
 from caendr.models.datastore import DatasetRelease
+from caendr.models.datastore.browser_track import BrowserTrack
 from caendr.models.sql import Strain
 from caendr.models.error import UnprocessableEntity, BadRequestError, NotFoundError
 
@@ -10,17 +11,10 @@ def get_release_bucket():
   return DatasetRelease.get_bucket_name()
 
 
-def get_release_path(release_version: str=None):
-  if not release_version:
-    release_version = get_latest_dataset_release_version()
-  
-  blob_prefix = DatasetRelease.get_blob_prefix()
-  return f'{blob_prefix}/{release_version}'
-
-
 def get_browser_tracks_path(release_version=None):
-  release_path = get_release_path()
-  return f'{release_path}/browser_tracks'
+  # TODO: Move this logic to BrowserTrack class (once all track files are in browser_tracks folder)
+  _, release_path = BrowserTrack.release_path()
+  return release_path + '/browser_tracks'
 
 
 # TODO: Does keys_only make sense as a parameter? Seems like it was originally used to limit the ds query

--- a/src/pkg/caendr/caendr/services/heritability_report.py
+++ b/src/pkg/caendr/caendr/services/heritability_report.py
@@ -59,7 +59,7 @@ def update_heritability_report_status(id: str, status: str=None, operation_name:
 
   h = HeritabilityReport.get_ds(id)
   if h is None:
-    raise NotFoundError(f'No Heritability Report with ID "{id}" was found.')
+    raise NotFoundError(HeritabilityReport, {'id': id})
 
   if status:
     h.set_properties(status=status)

--- a/src/pkg/caendr/caendr/services/indel_primer.py
+++ b/src/pkg/caendr/caendr/services/indel_primer.py
@@ -153,7 +153,7 @@ def update_indel_primer_status(id: str, status: str=None, operation_name: str=No
 
   m = IndelPrimer.get_ds(id)
   if m is None:
-    raise NotFoundError(f'No Indel Primer with ID "{id}" was found.')
+    raise NotFoundError(IndelPrimer, {'id': id})
 
   if status:
     m.set_properties(status=status)

--- a/src/pkg/caendr/caendr/services/nemascan_mapping.py
+++ b/src/pkg/caendr/caendr/services/nemascan_mapping.py
@@ -67,7 +67,7 @@ def update_nemascan_mapping_status(id: str, status: str=None, operation_name: st
 
   m = NemascanMapping.get_ds(id)
   if m is None:
-    raise NotFoundError(f'No Nemascan Mapping with ID "{id}" was found.')
+    raise NotFoundError(NemascanMapping, {'id': id})
 
   if status:
     m.set_properties(status=status)

--- a/src/pkg/caendr/caendr/services/sql/dataset/_env.py
+++ b/src/pkg/caendr/caendr/services/sql/dataset/_env.py
@@ -26,7 +26,7 @@ internal_db_blob_templates = {
     'GENE_GTF': remove_env_escape_chars( DB_OPS_FILEPATH + get_env_var('GENE_GTF_FILENAME') ),
     'GENE_GFF': remove_env_escape_chars( DB_OPS_FILEPATH + get_env_var('GENE_GFF_FILENAME') ),
     'GENE_IDS': remove_env_escape_chars( DB_OPS_FILEPATH + get_env_var('GENE_IDS_FILENAME') ),
-    'SVA_CSVGZ': f'{STRAIN_VARIANT_ANNOTATION_PATH}/WI.strain-annotation.bcsq.$SVA.csv.gz',
+    'SVA_CSVGZ': f'{STRAIN_VARIANT_ANNOTATION_PATH.raw_string}/WI.strain-annotation.bcsq.$SVA.csv.gz',
 }
 
 

--- a/src/pkg/caendr/caendr/utils/env.py
+++ b/src/pkg/caendr/caendr/utils/env.py
@@ -1,22 +1,12 @@
 import os
 from dotenv import load_dotenv
-from string import Template
 
 from caendr.services.logger import logger
+from caendr.utils.tokens import TokenizedString
 
 
 # Flag to track whether the environment has been loaded
 env_loaded = False
-
-# # TODO: Validate tokens?
-# VALID_TOKENS = {
-#   'SPECIES',
-#   'PRJ',
-#   'WB',
-#   'SVA',
-#   'RELEASE',
-#   'STRAIN',
-# }
 
 
 def load_env(dotenv_file='.env'):
@@ -66,7 +56,7 @@ def get_env_var(key, value=None, can_be_none=False, as_template=False):
 
   # Convert variable to a template string, if desired
   if as_template:
-    return Template(v.replace('{', '${'))
+    return TokenizedString(v.replace('{', '${'))
 
   # Return the value
   return v
@@ -80,37 +70,6 @@ def convert_env_bool(val: str):
   if val and val.lower() == 'true':
     return True
   return False
-
-
-
-def replace_species_tokens(s, species='$SPECIES', prj='$PRJ', wb='$WB', sva='$SVA', release='$RELEASE', strain='$STRAIN'):
-
-  # Get first argument as a string template
-  if isinstance(s, str):
-    t = Template(s)
-  elif isinstance(s, Template):
-    t = s
-  else:
-    raise ValueError(f'Cannot replace tokens in non-string value {s}')
-
-  # Perform substitutions
-  return t.substitute({
-    'SPECIES': species,
-    'RELEASE': release,
-    'WB':      wb,
-    'SVA':     sva,
-    'PRJ':     prj,
-    'STRAIN':  strain,
-  })
-
-
-# def replace_tokens_recursive(obj, **kwargs):
-#   if isinstance(obj, str):
-#     return replace_species_tokens(obj, **kwargs)
-#   elif isinstance(obj, dict):
-#     return { key: replace_tokens_recursive(val, **kwargs) for key, val in obj.items() }
-#   else:
-#     return obj
 
 
 

--- a/src/pkg/caendr/caendr/utils/tokens.py
+++ b/src/pkg/caendr/caendr/utils/tokens.py
@@ -1,0 +1,160 @@
+from string import Template
+
+from caendr.models.error import InvalidTokenError, MissingTokenError
+
+
+class TokenizedString():
+
+  def __init__(self, template):
+
+    # Initialize empty dict of tokens
+    self.tokens = {}
+
+    # Get argument as a string template
+    self.update_template_string(template)
+
+
+  def copy_with_tokens(self, **kwargs):
+    '''
+      Create a copy of this tokenized string, carrying over all set tokens.
+    '''
+    return TokenizedString(self.template).set_tokens(**kwargs)
+  
+
+  def __repr__(self):
+    if len(self.raw_string) <= 15:
+      return f'<TokenizedString: {self.raw_string}>'
+    else:
+      return f'<TokenizedString: {self.raw_string[:12]}...>'
+    
+
+  def __str__(self):
+    return self.raw_string
+
+
+
+  #
+  # Setting / Updating Template String
+  #
+
+  def update_template_string(self, template):
+    '''
+      Set the template string directly.
+    '''
+    if isinstance(template, str):
+      self.template = Template(template)
+    elif isinstance(template, Template):
+      self.template = template
+    else:
+      raise ValueError(f'Cannot replace tokens in non-string value {template}')
+    return self
+
+
+  def __add__(self, other):
+    '''
+      Use '+' operator to update the template string directly.
+    '''
+
+    # String - add directly to template
+    if isinstance(other, str):
+      return TokenizedString(self.raw_string + other).set_tokens(**self.tokens)
+    
+    # Template - add template string directly
+    elif isinstance(other, Template):
+      return TokenizedString(self.raw_string + other.template).set_tokens(**self.tokens)
+    
+    # Tokenized String - add templates, throwing error if token sets conflict
+    elif isinstance(other, TokenizedString):
+      for key in self.tokens:
+        if key in other.tokens and self.tokens[key] != other.tokens[key]:
+          raise InvalidTokenError(key)
+      return TokenizedString(self.raw_string + other.raw_string).set_tokens(**{**self.tokens, **other.tokens})
+    
+    # Other - throw error
+    else:
+      raise ValueError(f'Cannot replace tokens in non-string value {other}')
+
+
+
+  #
+  # Validation
+  #
+
+  VALID_TOKENS = {
+    'SPECIES',
+    'RELEASE', 'ver',
+    'PRJ',
+    'WB',
+    'SVA',
+    'STRAIN',
+  }
+
+  @classmethod
+  def is_valid_token(cls, key):
+    return key in cls.VALID_TOKENS
+
+  @classmethod
+  def validate_tokens(cls, **kwargs):
+    for key in kwargs:
+      if not cls.is_valid_token(key):
+        raise InvalidTokenError(key)
+
+
+
+  #
+  # Setting Tokens
+  #
+
+
+  def set_tokens(self, **kwargs):
+    for key, val in kwargs.items():
+      if self.is_valid_token(key):
+        self.tokens[key] = val
+      else:
+        raise InvalidTokenError(key)
+    return self
+
+
+
+  #
+  # String Conversion
+  #
+
+
+  def get_string(self, **kwargs):
+    '''
+      Apply all token replacements, throwing an error if any tokens remain unset.
+    '''
+    self.validate_tokens(**kwargs)
+    try:
+      return self.template.substitute(**{**self.tokens, **kwargs})
+    except:
+      raise MissingTokenError()
+
+
+  def get_string_safe(self, **kwargs):
+    '''
+      Apply all token replacements, ignoring any tokens that are unset.
+    '''
+    self.validate_tokens(**kwargs)
+    return self.template.safe_substitute(**{**self.tokens, **kwargs})
+
+
+  @property
+  def raw_string(self):
+    '''
+      Get the raw template string, without any replacements.
+    '''
+    # TODO: Make sure braces are included around tokens? For JS compatibility
+    return self.template.template
+
+
+
+
+# def replace_tokens_recursive(obj, **kwargs):
+#   if isinstance(obj, str):
+#     return replace_species_tokens(obj, **kwargs)
+#   elif isinstance(obj, dict):
+#     return { key: replace_tokens_recursive(val, **kwargs) for key, val in obj.items() }
+#   else:
+#     return obj

--- a/src/pkg/caendr/caendr/utils/tokens.py
+++ b/src/pkg/caendr/caendr/utils/tokens.py
@@ -82,7 +82,7 @@ class TokenizedString():
 
   VALID_TOKENS = {
     'SPECIES',
-    'RELEASE', 'ver',
+    'RELEASE',
     'PRJ',
     'WB',
     'SVA',


### PR DESCRIPTION
Creating new endpoint structure for data releases page.

- Create landing page endpoint for Data Releases
- Add species name to data release URLs
  - Redirects e.g. `c_elegans` to `c-elegans`
- Update NotFoundError to be more descriptive

Data file paths not fully updated yet for (1) new structure and (2) inclusion of species names. Handling in separate branch.