### PR TITLE
Use new browser track & FASTA filepaths

### DIFF
--- a/src/modules/site-v2/base/utils/markdown.py
+++ b/src/modules/site-v2/base/utils/markdown.py
@@ -19,7 +19,7 @@ def render_markdown(filename, directory="base/static/content/markdown"):
     return Markup(markdown.markdown(template))
 
 
-def render_ext_markdown(url: str, ignore_err=False):
+def render_ext_markdown(url: str, ignore_err=False, backup_text=None):
   if url is None:
     return ''
 
@@ -46,6 +46,8 @@ def render_ext_markdown(url: str, ignore_err=False):
   except ExternalMarkdownRenderError as ex:
     if ignore_err:
       logger.error(ex)
+      if backup_text is not None:
+        return Markup(markdown.markdown(backup_text))
     else:
       raise
 

--- a/src/modules/site-v2/base/views/data/releases.py
+++ b/src/modules/site-v2/base/views/data/releases.py
@@ -21,6 +21,7 @@ from base.utils.auth import jwt_required
 from caendr.api.strain import query_strains
 from caendr.api.isotype import get_isotypes
 from caendr.models.datastore import DatasetRelease, Species, SPECIES_LIST
+from caendr.models.datastore.browser_track import BrowserTrack
 from caendr.models.sql import Strain, StrainAnnotatedVariant
 from caendr.services.cloud.storage import generate_blob_url
 from caendr.services.dataset_release import get_all_dataset_releases, get_browser_tracks_path, get_release_bucket, find_dataset_release
@@ -83,6 +84,13 @@ def data_release_list(species, release_version=None):
   except NotFoundError:
     return abort(404)
 
+  # Get path to FASTA genome file for this species/release
+  fasta_path = BrowserTrack.get_fasta_path_full().get_string(**{
+    'SPECIES': species.name,
+    'RELEASE': release['version'],
+    'WB':      release['wormbase_version'],
+  })
+
   # Package common params into an object
   params = {
     'species':  species,
@@ -90,6 +98,8 @@ def data_release_list(species, release_version=None):
     'RELEASES': releases,
     'release_bucket': get_release_bucket(),
     'release_path': release.get_versioned_path_template().get_string(SPECIES = species.name),
+    'fasta_path': fasta_path,
+    'fasta_name': fasta_path.rsplit('/', 1)[1],
   }
 
   # Get list of files based on species

--- a/src/modules/site-v2/base/views/data/releases.py
+++ b/src/modules/site-v2/base/views/data/releases.py
@@ -103,8 +103,7 @@ def data_release_list(species, release_version=None):
   }
 
   # Get list of files based on species
-  # TODO: Pass in full species identifier (once DatasetRelease blob prefix is updated)
-  files = release.get_report_data_urls_map(species.name[2:])
+  files = release.get_report_data_urls_map(species.name)
 
   # Update params object with version-specific fields
   if release.report_type == DatasetRelease.V2:

--- a/src/modules/site-v2/base/views/tools/genome_browser.py
+++ b/src/modules/site-v2/base/views/tools/genome_browser.py
@@ -51,11 +51,11 @@ def get_tracks():
   return jsonify({
     'default': {
       track['name']: json.dumps( dict(track) )
-        for track in BrowserTrackDefault.query_ds_visible()
+        for track in BrowserTrackDefault.query_ds()
     },
     'templates': {
       track['template_name']: json.dumps( dict(track) )
-        for track in BrowserTrackTemplate.query_ds_visible()
+        for track in BrowserTrackTemplate.query_ds()
     },
   })
 
@@ -101,7 +101,7 @@ def genome_browser(region="III:11746923-11750250", query=None):
     'form': SpeciesSelectForm(),
 
     # Tracks
-    'default_tracks': sorted(BrowserTrackDefault.query_ds_visible(), key = lambda x: x['order'] ),
+    'default_tracks': sorted(BrowserTrackDefault.query_ds(), key = lambda x: x['order'] ),
 
     # Data locations
     'fasta_url': BrowserTrack.get_fasta_path_full().get_string_safe(),

--- a/src/modules/site-v2/base/views/tools/pairwise_indel_finder.py
+++ b/src/modules/site-v2/base/views/tools/pairwise_indel_finder.py
@@ -12,7 +12,6 @@ from caendr.models.datastore import Species, SPECIES_LIST, IndelPrimer
 from caendr.models.error import NotFoundError, NonUniqueEntity, ReportLookupError, EmptyReportDataError, EmptyReportResultsError
 from caendr.models.task import TaskStatus
 from caendr.services.cloud.storage import check_blob_exists
-from caendr.services.dataset_release import get_browser_tracks_path
 from caendr.utils.constants import CHROM_NUMERIC
 from caendr.utils.data import get_file_format
 

--- a/src/modules/site-v2/templates/_includes/strain-listing.html
+++ b/src/modules/site-v2/templates/_includes/strain-listing.html
@@ -77,7 +77,7 @@
  #}
 {% macro replace_tokens(target_var, species_var, tokens) %}
   // TODO: Uses of species name ID in filenames not yet standardized, so we drop the 'c_' prefix for now
-  {{target_var}} = {{target_var}}.replaceAll('${SPECIES}', {{species_var}}['name'].substring(2));
+  {{target_var}} = {{target_var}}.replaceAll('${SPECIES}', {{species_var}}['name']);
   {% for token, field in tokens.items() -%}
   {{target_var}} = {{target_var}}.replaceAll('${' + '{{ token }}' + '}', {{species_var}}['{{ field }}']);
   {% endfor -%}

--- a/src/modules/site-v2/templates/data/v2.html
+++ b/src/modules/site-v2/templates/data/v2.html
@@ -42,7 +42,7 @@
                     <div class="row">
                         <div class="col-6">
                             <h2>Release Notes</h2>
-                            <p>{{ render_ext_markdown(files.get('release_notes')) }}</p>
+                            <p>{{ render_ext_markdown(files.get('release_notes'), ignore_err=true, backup_text="*Release notes are not available at this time.*") }}</p>
                         </div>
                         <div class="col-6">
                             <div class="card">

--- a/src/modules/site-v2/templates/data/v2.html
+++ b/src/modules/site-v2/templates/data/v2.html
@@ -221,9 +221,9 @@
                                             <th scope="row">Reference Genome FASTA ({{ RELEASE.wormbase_version }})</th>
                                             <td>The reference genome build from Wormbase used for alignment and
                                                 annotation.</td>
-                                            <td class="text-center"><a class="btn btn-primary text-light"
-                                                    href="ftp://ftp.wormbase.org/pub/wormbase/releases/{{ RELEASE.wormbase_version }}/species/c_elegans/PRJNA13758/c_elegans.PRJNA13758.{{ RELEASE.wormbase_version }}.genomic.fa.gz">c_elegans.PRJNA13758.{{
-                                                    RELEASE.wormbase_version }}.genomic.fa.gz</a></td>
+                                            <td class="text-center">
+                                                <a class="btn btn-primary text-light" href="{{ fasta_path }}">{{ fasta_name }}</a>
+                                            </td>
                                         </tr>
                                         <tr>
                                             <th scope="row">Transposon Calls</th>

--- a/src/pkg/caendr/caendr/models/datastore/browser_track.py
+++ b/src/pkg/caendr/caendr/models/datastore/browser_track.py
@@ -26,7 +26,7 @@ class BrowserTrack(Entity):
   @staticmethod
   def release_path():
     # TODO: add /browser_tracks to end of path, once all track files are in this folder
-    return (DatasetRelease.get_bucket_name(), DatasetRelease.get_path_template())
+    return (DatasetRelease.get_bucket_name(), DatasetRelease.get_path_template() + '/browser_tracks')
 
   @staticmethod
   def bam_bai_path():
@@ -47,7 +47,7 @@ class BrowserTrack(Entity):
 
   @staticmethod
   def get_fasta_filename():
-    return TokenizedString('browser_tracks/c_${SPECIES}.${PRJ}.${WB}.genome.fa')
+    return TokenizedString('${RELEASE}_${SPECIES}.${WB}.genome.fa')
 
   @staticmethod
   def get_fasta_path_full():

--- a/src/pkg/caendr/caendr/models/datastore/browser_track.py
+++ b/src/pkg/caendr/caendr/models/datastore/browser_track.py
@@ -65,7 +65,6 @@ class BrowserTrack(Entity):
       'filename',
       'name',
       'order',
-      'hidden',
       'params',
     }
 
@@ -98,18 +97,6 @@ class BrowserTrack(Entity):
     self.__dict__['params'] = {
       k: v for k, v in val.items() if k not in ['name', 'order', 'url', 'indexURL']
     }
-
-
-  ## Querying ##
-
-  @classmethod
-  def query_ds_visible(cls, *args, **kwargs):
-    '''
-      Query only Browser Tracks that are not hidden.
-      Equivalent to adding filter 'hidden = False' to the regular Entity.query_ds() method.
-    '''
-    kwargs['filters'] = [ *kwargs.get('filters', {}), ('hidden', '=', False) ]
-    return cls.query_ds(*args, **kwargs)
 
 
   

--- a/src/pkg/caendr/caendr/models/datastore/dataset_release.py
+++ b/src/pkg/caendr/caendr/models/datastore/dataset_release.py
@@ -48,7 +48,7 @@ class ReportType():
 class DatasetRelease(Entity):
   kind = "dataset_release"
   __bucket_name = MODULE_SITE_BUCKET_PUBLIC_NAME
-  __blob_prefix = kind + '/c_${SPECIES}'
+  __blob_prefix = kind + '/${SPECIES}'
 
 
   def __repr__(self):

--- a/src/pkg/caendr/caendr/services/dataset_release.py
+++ b/src/pkg/caendr/caendr/services/dataset_release.py
@@ -12,9 +12,8 @@ def get_release_bucket():
 
 
 def get_browser_tracks_path(release_version=None):
-  # TODO: Move this logic to BrowserTrack class (once all track files are in browser_tracks folder)
   _, release_path = BrowserTrack.release_path()
-  return release_path + '/browser_tracks'
+  return release_path
 
 
 # TODO: Does keys_only make sense as a parameter? Seems like it was originally used to limit the ds query

--- a/src/pkg/caendr/caendr/utils/tokens.py
+++ b/src/pkg/caendr/caendr/utils/tokens.py
@@ -116,7 +116,7 @@ class TokenizedString():
 
   def set_tokens_from_species(self, species):
     return self.set_tokens(**{
-      'SPECIES': species.name[2:],
+      'SPECIES': species.name,
       'RELEASE': species['latest_release'],
       'PRJ':     species['project_num'],
       'WB':      species['wb_ver'],


### PR DESCRIPTION
Updated to match new values in rosetta stone document.

Currently, two copies of each file exist in GCP, one with the old name and one with the new name.  Once all code is using the new names, we can delete the old files.

Also adds fallback text if Release Notes file can't be loaded.