### PR TITLE
Fix PipelineOperation status update

### DIFF
--- a/src/modules/api/pipeline-task/routes/task.py
+++ b/src/modules/api/pipeline-task/routes/task.py
@@ -133,8 +133,8 @@ def update_task():
       logger.debug("updating the pipeline operation record...")
       op = update_pipeline_operation_record(operation)
 
-      logger.debug(f"updating all linked status records for operation: {op}")
-      update_all_linked_status_records(op.operation_kind, operation)
+      logger.debug(f"updating all linked status records for operation {op}: {dict(op)}")
+      update_all_linked_status_records(op['operation_kind'], operation)
       logger.debug(operation)
     except Exception as e:
       logger.error(f"Unable to update pipeline record[s]: {e}")


### PR DESCRIPTION
Access field `operation_kind` using bracket notation, which should (hopefully) fix the constant status update errors.

Tested locally using `Run API pipeline server` launch config.