### PR TITLE
Demote report_path for ERROR'd Nemascan report to warning

### DIFF
--- a/src/pkg/caendr/caendr/models/datastore/nemascan_mapping.py
+++ b/src/pkg/caendr/caendr/models/datastore/nemascan_mapping.py
@@ -76,11 +76,11 @@ class NemascanMapping(DataJobEntity):
       if check_blob_exists(self.get_bucket_name(), path):
         return path
       else:
-        logger.error(f'Genetic Mapping report {self.id} lists its report path as "{path}", but this file does not exist. Recomputing...')
+        logger.warn(f'Genetic Mapping report {self.id} lists its report path as "{path}", but this file does not exist. Recomputing...')
 
     # If job threw an error, don't search for report path
     if self['status'] == TaskStatus.ERROR:
-      logger.error(f'Trying to compute report path for Genetic Mapping report "{self.id}", but job returned an error.')
+      logger.warn(f'Trying to compute report path for Genetic Mapping report "{self.id}", but job returned an error. Returning None.')
       return None
 
     # Get a list of all files with this report's prefix


### PR DESCRIPTION
This case doesn't break anything, since all callers check if the computed value is `None`.