### PR TITLE
Allow user to re-run reports that ended in ERROR

### DIFF
--- a/src/modules/site-v2/base/utils/tools.py
+++ b/src/modules/site-v2/base/utils/tools.py
@@ -135,7 +135,7 @@ def try_submit(EntityClass, user, data, no_cache):
     return {
       'cached':    True,
       'same_user': True,
-      'ready':     ex.report['status'] == TaskStatus.COMPLETE,
+      'ready':     TaskStatus.is_finished( ex.report['status'] ),
       'data_hash': ex.report.data_hash,
       'id':        ex.report.id,
       'message':   'You have already submitted this data file. Here\'s your previously generated report.',
@@ -151,7 +151,7 @@ def try_submit(EntityClass, user, data, no_cache):
     return {
       'cached':    True,
       'same_user': False,
-      'ready':     ex.report['status'] == TaskStatus.COMPLETE,
+      'ready':     TaskStatus.is_finished( ex.report['status'] ),
       'data_hash': ex.report.data_hash,
       'id':        ex.report.id,
       'message':   'A matching report was found.',

--- a/src/modules/site-v2/base/utils/tools.py
+++ b/src/modules/site-v2/base/utils/tools.py
@@ -15,7 +15,7 @@ from caendr.models.error import (
     FileUploadError,
     ReportLookupError,
 )
-from caendr.models.task import TaskStatus
+from caendr.models.task import Task
 from caendr.services.tools import submit_job
 from caendr.utils.data import unique_id
 from caendr.services.cloud.secret import get_secret
@@ -135,7 +135,7 @@ def try_submit(EntityClass, user, data, no_cache):
     return {
       'cached':    True,
       'same_user': True,
-      'ready':     TaskStatus.is_finished( ex.report['status'] ),
+      'ready':     Task.is_finished( ex.report['status'] ),
       'data_hash': ex.report.data_hash,
       'id':        ex.report.id,
       'message':   'You have already submitted this data file. Here\'s your previously generated report.',
@@ -151,7 +151,7 @@ def try_submit(EntityClass, user, data, no_cache):
     return {
       'cached':    True,
       'same_user': False,
-      'ready':     TaskStatus.is_finished( ex.report['status'] ),
+      'ready':     Task.is_finished( ex.report['status'] ),
       'data_hash': ex.report.data_hash,
       'id':        ex.report.id,
       'message':   'A matching report was found.',

--- a/src/pkg/caendr/caendr/models/datastore/data_job_entity.py
+++ b/src/pkg/caendr/caendr/models/datastore/data_job_entity.py
@@ -138,16 +138,16 @@ class DataJobEntity(JobEntity, UserOwnedEntity):
       ('username',  '=', username),
     ]
 
-    # If desired, filter by status as well
-    if status:
-      filters += [('status', '=', status)]
+    # Convert status to list, if a single value passed
+    if status is not None and not hasattr(status, '__iter__'):
+      status = [status]
 
     # Loop through each matching report, sorted newest to oldest
     # Prefer a match with a date, if one exists
     for match in cls.sort_by_created_date( cls.query_ds(filters=filters), set_none_max=True ):
 
-      # If containers match, return the matching Entity
-      if match.container_equals(container):
+      # If containers match and status is correct, return the matching Entity
+      if match.container_equals(container) and (status and match['status'] in status):
         return match
 
 

--- a/src/pkg/caendr/caendr/models/task.py
+++ b/src/pkg/caendr/caendr/models/task.py
@@ -32,6 +32,10 @@ class TaskStatus:
       TaskStatus.SUBMITTED,
     ]
 
+  @staticmethod
+  def is_finished(status):
+    return status in [ TaskStatus.COMPLETE, TaskStatus.ERROR ]
+
 class Task(object):
 
   # A human readable name for this Task type

--- a/src/pkg/caendr/caendr/models/task.py
+++ b/src/pkg/caendr/caendr/models/task.py
@@ -32,22 +32,6 @@ class TaskStatus:
       TaskStatus.SUBMITTED,
     ]
 
-  @staticmethod
-  def finished():
-    return [ TaskStatus.COMPLETE, TaskStatus.ERROR ]
-
-  @staticmethod
-  def is_finished(status):
-    return status in TaskStatus.finished()
-
-  @staticmethod
-  def not_err():
-    return [ TaskStatus.SUBMITTED, TaskStatus.RUNNING, TaskStatus.COMPLETE ]
-
-  @staticmethod
-  def is_not_err(status):
-    return status in TaskStatus.not_err()
-
 
 
 class Task(object):
@@ -156,6 +140,25 @@ class Task(object):
       raise ValueError(f'Target queue is undefined for task of type "{self.name}".')
 
     return add_task( self.queue, self.queue_url, dict(self) )
+
+
+  ## Task Status Helpers ##
+
+  @staticmethod
+  def finished():
+    return [ TaskStatus.COMPLETE, TaskStatus.ERROR ]
+
+  @staticmethod
+  def is_finished(status):
+    return status in Task.finished()
+
+  @staticmethod
+  def not_err():
+    return [ TaskStatus.SUBMITTED, TaskStatus.RUNNING, TaskStatus.COMPLETE ]
+
+  @staticmethod
+  def is_not_err(status):
+    return status in Task.not_err()
 
 
 

--- a/src/pkg/caendr/caendr/models/task.py
+++ b/src/pkg/caendr/caendr/models/task.py
@@ -33,8 +33,22 @@ class TaskStatus:
     ]
 
   @staticmethod
+  def finished():
+    return [ TaskStatus.COMPLETE, TaskStatus.ERROR ]
+
+  @staticmethod
   def is_finished(status):
-    return status in [ TaskStatus.COMPLETE, TaskStatus.ERROR ]
+    return status in TaskStatus.finished()
+
+  @staticmethod
+  def not_err():
+    return [ TaskStatus.SUBMITTED, TaskStatus.RUNNING, TaskStatus.COMPLETE ]
+
+  @staticmethod
+  def is_not_err(status):
+    return status in TaskStatus.not_err()
+
+
 
 class Task(object):
 

--- a/src/pkg/caendr/caendr/services/tools/submit.py
+++ b/src/pkg/caendr/caendr/services/tools/submit.py
@@ -187,7 +187,7 @@ class SubmissionManager():
 
     # Check if user has already submitted this job, and "return" it in a duplicate data error if so
     if not no_cache:
-      cached_entity = cls.check_cached_submission(data_hash, user.name, container)
+      cached_entity = cls.check_cached_submission(data_hash, user.name, container, status=TaskStatus.COMPLETE)
       if cached_entity:
         raise DuplicateDataError(cached_entity)
 

--- a/src/pkg/caendr/caendr/services/tools/submit.py
+++ b/src/pkg/caendr/caendr/services/tools/submit.py
@@ -187,7 +187,7 @@ class SubmissionManager():
 
     # Check if user has already submitted this job, and "return" it in a duplicate data error if so
     if not no_cache:
-      cached_entity = cls.check_cached_submission(data_hash, user.name, container, status=TaskStatus.COMPLETE)
+      cached_entity = cls.check_cached_submission(data_hash, user.name, container, status=TaskStatus.not_err())
       if cached_entity:
         raise DuplicateDataError(cached_entity)
 

--- a/src/pkg/caendr/caendr/services/tools/submit.py
+++ b/src/pkg/caendr/caendr/services/tools/submit.py
@@ -6,7 +6,7 @@ from caendr.services.logger import logger
 
 from caendr.models.datastore import Container, IndelPrimer, HeritabilityReport, NemascanMapping, SPECIES_LIST
 from caendr.models.error     import CachedDataError, DuplicateDataError, DataFormatError
-from caendr.models.task      import TaskStatus, IndelPrimerTask, HeritabilityTask, NemaScanTask
+from caendr.models.task      import Task, TaskStatus, IndelPrimerTask, HeritabilityTask, NemaScanTask
 
 from caendr.api.strain             import query_strains
 from caendr.api.isotype            import get_distinct_isotypes
@@ -187,7 +187,7 @@ class SubmissionManager():
 
     # Check if user has already submitted this job, and "return" it in a duplicate data error if so
     if not no_cache:
-      cached_entity = cls.check_cached_submission(data_hash, user.name, container, status=TaskStatus.not_err())
+      cached_entity = cls.check_cached_submission(data_hash, user.name, container, status=Task.not_err())
       if cached_entity:
         raise DuplicateDataError(cached_entity)
 


### PR DESCRIPTION
Includes better checking for whether a job is:
- `finished`: `COMPLETE` or `ERROR`
- `not_err`: `SUBMITTED`, `RUNNING`, or `COMPLETE`