### PR TITLE
Make DatabaseOperation a subclass of JobEntity & UserOwnedEntity

### DIFF
--- a/src/modules/site-v2/base/views/admin/etl.py
+++ b/src/modules/site-v2/base/views/admin/etl.py
@@ -83,13 +83,11 @@ def create_op():
 
   db_op = request.form.get('db_op')
   note = request.form.get('note')
-  username = get_jwt_identity()
   user = get_current_user()
-  email = user.email
 
   args = {
     'SPECIES_LIST': form.data.get('species'),
   }
 
-  create_new_db_op(db_op, username, email, args=args, note=note)
+  create_new_db_op(db_op, user, args=args, note=note)
   return redirect(url_for("admin_etl_op.admin_etl_op"), code=302)

--- a/src/pkg/caendr/caendr/models/datastore/data_job_entity.py
+++ b/src/pkg/caendr/caendr/models/datastore/data_job_entity.py
@@ -5,7 +5,6 @@ from caendr.services.logger import logger
 from caendr.models.datastore import JobEntity, UserOwnedEntity
 
 from caendr.services.cloud.storage import check_blob_exists
-from caendr.utils.data import unique_id
 
 
 
@@ -38,16 +37,6 @@ class DataJobEntity(JobEntity, UserOwnedEntity):
       raise TypeError(f"Class '{cls.__name__}' should never be instantiated directly -- subclasses should be used instead.")
     return super(DataJobEntity, cls).__new__(cls)
 
-
-  def __init__(self, name_or_obj = None, *args, **kwargs):
-
-    # If nothing passed for name_or_obj, create a new ID to use for this object
-    if name_or_obj is None:
-      name_or_obj = unique_id()
-      self.set_properties_meta(id = name_or_obj)
-
-    # Initialize from superclass
-    super().__init__(name_or_obj, *args, **kwargs)
 
 
   @classmethod
@@ -90,7 +79,6 @@ class DataJobEntity(JobEntity, UserOwnedEntity):
   def get_props_set_meta(cls):
     return {
       *super().get_props_set_meta(),
-      'id',
       'data_hash',
     }
 
@@ -104,14 +92,6 @@ class DataJobEntity(JobEntity, UserOwnedEntity):
   ## Meta props ##
 
   # Meta props are stored in self.__dict__ by default.
-
-  @property
-  def id(self):
-    '''
-      This Entity's unique ID.
-      This field cannot be set manually; it must be determined at initialization.
-    '''
-    return self._get_meta_prop('id')
 
   @property
   def data_hash(self):

--- a/src/pkg/caendr/caendr/models/datastore/database_operation.py
+++ b/src/pkg/caendr/caendr/models/datastore/database_operation.py
@@ -20,7 +20,6 @@ class DatabaseOperation(JobEntity):
       *super().get_props_set(),
 
       # Submission
-      'id',
       'username',
       'email',
 

--- a/src/pkg/caendr/caendr/models/datastore/database_operation.py
+++ b/src/pkg/caendr/caendr/models/datastore/database_operation.py
@@ -1,12 +1,12 @@
 import os
 
-from caendr.models.datastore import JobEntity
+from caendr.models.datastore import JobEntity, UserOwnedEntity
 
 
 MODULE_DB_OPERATIONS_BUCKET_NAME = os.environ.get('MODULE_DB_OPERATIONS_BUCKET_NAME')
 
 
-class DatabaseOperation(JobEntity):
+class DatabaseOperation(JobEntity, UserOwnedEntity):
   kind = 'database_operation'
   __bucket_name = MODULE_DB_OPERATIONS_BUCKET_NAME
 
@@ -18,12 +18,6 @@ class DatabaseOperation(JobEntity):
   def get_props_set(cls):
     return {
       *super().get_props_set(),
-
-      # Submission
-      'username',
-      'email',
-
-      # Other
       'note',
       'db_operation',
       'args',

--- a/src/pkg/caendr/caendr/models/datastore/gene_browser_tracks.py
+++ b/src/pkg/caendr/caendr/models/datastore/gene_browser_tracks.py
@@ -26,7 +26,6 @@ class GeneBrowserTracks(JobEntity):
       *super().get_props_set(),
 
       # Submission
-      'id',
       'username',
 
       # Query

--- a/src/pkg/caendr/caendr/models/datastore/job_entity.py
+++ b/src/pkg/caendr/caendr/models/datastore/job_entity.py
@@ -2,6 +2,7 @@ from caendr.services.logger import logger
 
 from caendr.models.datastore import Container, Entity
 from caendr.models.datastore.pipeline_operation import PipelineOperation
+from caendr.utils.data import unique_id
 
 
 
@@ -38,13 +39,18 @@ class JobEntity(Entity):
     return super(JobEntity, cls).__new__(cls)
 
 
-  def __init__(self, *args, **kwargs):
+  def __init__(self, name_or_obj = None, *args, **kwargs):
 
     # Create Container object to store relevant Container fields
     self.__container = Container()
 
+    # If nothing passed for name_or_obj, create a new ID to use for this object
+    if name_or_obj is None:
+      name_or_obj = unique_id()
+      self.set_properties_meta(id = name_or_obj)
+
     # Initialize from superclass
-    super().__init__(*args, **kwargs)
+    super().__init__(name_or_obj, *args, **kwargs)
 
 
 
@@ -65,6 +71,26 @@ class JobEntity(Entity):
       'operation_name',
       'status',
     }
+
+
+  @classmethod
+  def get_props_set_meta(cls):
+    return {
+      *super().get_props_set_meta(),
+      'id',
+    }
+
+
+
+  ## Unique ID ##
+
+  @property
+  def id(self):
+    '''
+      This Entity's unique ID.
+      This field cannot be set manually; it must be determined at initialization.
+    '''
+    return self._get_meta_prop('id')
 
 
 

--- a/src/pkg/caendr/caendr/services/database_operation.py
+++ b/src/pkg/caendr/caendr/services/database_operation.py
@@ -2,7 +2,7 @@ import os
 from caendr.services.logger import logger
 from sqlalchemy import func 
 
-from caendr.models.datastore import DatabaseOperation
+from caendr.models.datastore import DatabaseOperation, Container
 from caendr.models.task import DatabaseOperationTask, TaskStatus
 from caendr.models.sql import Homolog, StrainAnnotatedVariant, Strain, WormbaseGene, WormbaseGeneSummary
 from caendr.services.tool_versions import GCR_REPO_NAME
@@ -95,21 +95,23 @@ def get_db_op_form_options():
 def create_new_db_op(op, username, email, args=None, note=None):
   logger.debug(f'Creating new Database Operation: op:{op}, username:{username}, email:{email}, args:{args}, note:{note}')
 
-  # Compute unique ID for new Database Operation entity
-  id = unique_id()
+  # Get the DB Operations container from datastoer
+  container = Container.get(MODULE_DB_OPERATIONS_CONTAINER_NAME)
 
   # Create Database Operation entity & upload to datastore
-  db_op = DatabaseOperation(id, **{
-    'id':                id,
+  db_op = DatabaseOperation(**{
     'username':          username,
     'email':             email,
     'note':              note,
     'db_operation':      op,
     'args':              args,
-    'container_repo':    GCR_REPO_NAME,
-    'container_name':    MODULE_DB_OPERATIONS_CONTAINER_NAME,
-    'container_version': MODULE_DB_OPERATIONS_CONTAINER_VERSION,
   })
+
+  # Set entity's container & user fields
+  db_op.set_container(container)
+
+  # Upload the new entity to datastore
+  db_op['status'] = TaskStatus.SUBMITTED
   db_op.save()
 
   # Schedule mapping in task queue


### PR DESCRIPTION
Class now uses updated logic for tracking unique ID, container version, and owner's user account.

Fixes bug with `database_operation` using container version from `module.env` instead of from GCP.

`database_operation` entity no longer explicitly tracks user's email, since it can be retrieved using the `username` field.  The corresponding `Task` object, however, does still take the email address, so this does not interfere with how it currently sends the notification email.