### PR TITLE
Fix/tool columns wrapping

### DIFF
--- a/src/modules/site-v2/templates/tools/genome_browser/gbrowser.html
+++ b/src/modules/site-v2/templates/tools/genome_browser/gbrowser.html
@@ -29,7 +29,7 @@
 
 <div class="container-fluid px-5">
   <div class="d-flex justify-content-around flex-wrap mt-2 pb-5">
-    <div class="col-10 col-md-8 col-xl-3 mb-5" style="max-height:80vh;">
+    <div class="col-10 col-md-8 col-xl-3">
       <nav>
         <div class="nav nav-tabs border-0" id="nav-tab" role="tablist">
           <button class="nav-link active" id="nav-home-tab" data-bs-toggle="tab" data-bs-target="#nav-home"
@@ -160,7 +160,7 @@
       </div>
     </div>
   <!-- Tool column -->
-  <div class="d-flex flex-wrap flex-column col-md-12 col-xl-8 mt-5 mt-xl-0">
+  <div class="d-flex flex-wrap flex-column col-md-12 col-xl-8">
       <!-- Options Toolbar -->
       <div id="options-toolbar" class="d-flex flex-wrap justify-content-end col-12 text-end mb-3 optionsToolbar">
         <div class="ps-3 pt-0" style="display: none;">

--- a/src/modules/site-v2/templates/tools/variant_annotation/vbrowser.html
+++ b/src/modules/site-v2/templates/tools/variant_annotation/vbrowser.html
@@ -19,8 +19,8 @@
 {% from "_includes/strain-listing.html" import list_strains %}
 
 <div class="container-fluid px-5">
-  <div class="d-flex justify-content-around flex-wrap mt-2 pb-5">
-    <div class="col-10 col-md-8 col-xl-3 mb-5" style="max-height:80vh;">
+  <div class="d-flex justify-content-around flex-wrap pb-5">
+    <div class="col-10 col-md-8 col-xl-3">
       <nav>
         <div class="nav nav-tabs border-0" id="nav-tab" role="tablist">
           <button class="nav-link active" id="nav-home-tab" data-bs-toggle="tab" data-bs-target="#nav-home"


### PR DESCRIPTION
Removed the max-height from the input column for Genome Browser and Variant Annotation because it was causing elements to overlap on screens with a 3:2 aspect ratio (e.g., Pixelbook). 