### PR TITLE
Db ops drop tables fix + preflight check

### DIFF
--- a/env/development/global.env
+++ b/env/development/global.env
@@ -93,6 +93,7 @@ MODULE_DB_OPERATIONS_SVA_FILEPATH=strain_variant_annotation/{SPECIES}
 GENE_GTF_FILENAME=canonical_geneset.gtf.gz
 GENE_GFF_FILENAME=annotations.gff3.gz
 GENE_IDS_FILENAME=current.geneIDs.txt.gz
+SVA_CSVGZ_FILENAME={SPECIES}.strain-annotation.bcsq.{SVA}.tsv.gz
 
 
 ###########################################################################

--- a/env/development/global.env
+++ b/env/development/global.env
@@ -86,7 +86,13 @@ MODULE_DB_OPERATIONS_SOCKET_PATH=/cloudsql
 MODULE_DB_OPERATIONS_TASK_QUEUE_NAME=db
 
 EXTERNAL_DB_BACKUP_PATH=db/external
-STRAIN_VARIANT_ANNOTATION_PATH=strain_variant_annotation/{SPECIES}
+
+MODULE_DB_OPERATIONS_RELEASE_FILEPATH=reference_genome/{SPECIES}/{RELEASE}
+MODULE_DB_OPERATIONS_SVA_FILEPATH=strain_variant_annotation/{SPECIES}
+
+GENE_GTF_FILENAME=canonical_geneset.gtf.gz
+GENE_GFF_FILENAME=annotations.gff3.gz
+GENE_IDS_FILENAME=current.geneIDs.txt.gz
 
 
 ###########################################################################

--- a/env/main/global.env
+++ b/env/main/global.env
@@ -84,7 +84,13 @@ MODULE_DB_OPERATIONS_SOCKET_PATH=/cloudsql
 MODULE_DB_OPERATIONS_TASK_QUEUE_NAME=etl-operation
 
 EXTERNAL_DB_BACKUP_PATH=db/external
-STRAIN_VARIANT_ANNOTATION_PATH=strain_variant_annotation/{SPECIES}
+
+MODULE_DB_OPERATIONS_RELEASE_FILEPATH=reference_genome/{SPECIES}/{RELEASE}
+MODULE_DB_OPERATIONS_SVA_FILEPATH=strain_variant_annotation/{SPECIES}
+
+GENE_GTF_FILENAME=canonical_geneset.gtf.gz
+GENE_GFF_FILENAME=annotations.gff3.gz
+GENE_IDS_FILENAME=current.geneIDs.txt.gz
 
 
 ###########################################################################

--- a/env/main/global.env
+++ b/env/main/global.env
@@ -91,6 +91,7 @@ MODULE_DB_OPERATIONS_SVA_FILEPATH=strain_variant_annotation/{SPECIES}
 GENE_GTF_FILENAME=canonical_geneset.gtf.gz
 GENE_GFF_FILENAME=annotations.gff3.gz
 GENE_IDS_FILENAME=current.geneIDs.txt.gz
+SVA_CSVGZ_FILENAME={SPECIES}.strain-annotation.bcsq.{SVA}.tsv.gz
 
 
 ###########################################################################

--- a/env/qa/global.env
+++ b/env/qa/global.env
@@ -85,7 +85,14 @@ MODULE_DB_OPERATIONS_SOCKET_PATH=/tmp/cloudsql
 MODULE_DB_OPERATIONS_TASK_QUEUE_NAME=db
 
 EXTERNAL_DB_BACKUP_PATH=db/external
-STRAIN_VARIANT_ANNOTATION_PATH=strain_variant_annotation/{SPECIES}
+
+MODULE_DB_OPERATIONS_RELEASE_FILEPATH=reference_genome/{SPECIES}/{RELEASE}
+MODULE_DB_OPERATIONS_SVA_FILEPATH=strain_variant_annotation/{SPECIES}
+
+GENE_GTF_FILENAME=canonical_geneset.gtf.gz
+GENE_GFF_FILENAME=annotations.gff3.gz
+GENE_IDS_FILENAME=current.geneIDs.txt.gz
+
 
 ###########################################################################
 #                        API Pipeline Task Properties                     #

--- a/env/qa/global.env
+++ b/env/qa/global.env
@@ -92,6 +92,7 @@ MODULE_DB_OPERATIONS_SVA_FILEPATH=strain_variant_annotation/{SPECIES}
 GENE_GTF_FILENAME=canonical_geneset.gtf.gz
 GENE_GFF_FILENAME=annotations.gff3.gz
 GENE_IDS_FILENAME=current.geneIDs.txt.gz
+SVA_CSVGZ_FILENAME={SPECIES}.strain-annotation.bcsq.{SVA}.tsv.gz
 
 
 ###########################################################################

--- a/src/modules/db_operations/module.env
+++ b/src/modules/db_operations/module.env
@@ -1,7 +1,2 @@
 MODULE_NAME=caendr-db-operations
 MODULE_VERSION=v1.0.39a
-
-DB_OPS_FILEPATH="reference_genome/\${SPECIES}/\${RELEASE}/"
-GENE_GTF_FILENAME="canonical_geneset.gtf.gz"
-GENE_GFF_FILENAME="annotations.gff3.gz"
-GENE_IDS_FILENAME="current.geneIDs.txt.gz"

--- a/src/modules/site-v2/base/views/admin/etl.py
+++ b/src/modules/site-v2/base/views/admin/etl.py
@@ -12,14 +12,16 @@ from caendr.services.database_operation import get_all_db_ops, get_all_db_stats,
 
 from google.cloud import storage
 
+
 ETL_LOGS_BUCKET_NAME = os.getenv('ETL_LOGS_BUCKET_NAME')
 
 storage_client = storage.Client()
 
 
-admin_etl_op_bp = Blueprint('admin_etl_op',
-                            __name__,
-                            template_folder='templates')
+admin_etl_op_bp = Blueprint(
+  'admin_etl_op', __name__, template_folder='templates'
+)
+
 
 
 @admin_etl_op_bp.route('', methods=["GET"])
@@ -61,26 +63,38 @@ def view_op(id):
       log_contents = blob.download_as_string().decode('utf8')
       log_contents.replace("\n", "<br/>")
 
-        
-
   format = request.args.get('format')
   if format == 'json':
     return json.dumps(op, indent=4, sort_keys=True, default=str)
 
   return render_template('admin/etl/view.html', **locals())
 
+
+
 @admin_etl_op_bp.route('/create', methods=["GET", "POST"])
 @admin_required()
 def create_op():
-  title = 'Execute a Database Operation'
-  alt_parent_breadcrumb = {"title": "Admin/ETL", "url": url_for('admin_etl_op.admin_etl_op')}
 
-  jwt_csrf_token = (get_jwt() or {}).get("csrf")
+  # Set up the form
   form = AdminCreateDatabaseOperationForm(request.form)
   form.db_op.choices = get_db_op_form_options()
-  if not (request.method == 'POST' and form.validate_on_submit()):
-    return render_template('admin/etl/create.html', **locals())
 
+  ## GET Request ##
+  # Show the form page
+  if not (request.method == 'POST' and form.validate_on_submit()):
+    return render_template('admin/etl/create.html', **{
+      'title': 'Execute a Database Operation',
+      'alt_parent_breadcrumb': { "title": "Admin/ETL", "url": url_for('admin_etl_op.admin_etl_op') },
+
+      # Form
+      'jwt_csrf_token': (get_jwt() or {}).get("csrf"),
+      'form': form,
+    })
+
+  ## POST Request ##
+  # Submit the form
+
+  # Extract form fields
   db_op = request.form.get('db_op')
   note = request.form.get('note')
   user = get_current_user()
@@ -89,5 +103,6 @@ def create_op():
     'SPECIES_LIST': form.data.get('species'),
   }
 
+  # Create the job and redirect back to the full list
   create_new_db_op(db_op, user, args=args, note=note)
   return redirect(url_for("admin_etl_op.admin_etl_op"), code=302)

--- a/src/pkg/caendr/caendr/services/sql/dataset/_env.py
+++ b/src/pkg/caendr/caendr/services/sql/dataset/_env.py
@@ -5,8 +5,8 @@ from caendr.utils.env import get_env_var, remove_env_escape_chars
 
 # Get environment variables
 MODULE_DB_OPERATIONS_BUCKET_NAME = get_env_var('MODULE_DB_OPERATIONS_BUCKET_NAME')
-STRAIN_VARIANT_ANNOTATION_PATH   = get_env_var('STRAIN_VARIANT_ANNOTATION_PATH', as_template=True)
-DB_OPS_FILEPATH                  = get_env_var('DB_OPS_FILEPATH')
+RELEASE_FILEPATH = get_env_var('MODULE_DB_OPERATIONS_RELEASE_FILEPATH', as_template=True)
+SVA_FILEPATH     = get_env_var('MODULE_DB_OPERATIONS_SVA_FILEPATH',     as_template=True)
 
 
 # Construct URL templates for external DBs (not managed by CaeNDR)
@@ -23,10 +23,10 @@ external_db_url_templates = {
 
 # Construct URL templates for internal DBs (managed by CaeNDR)
 internal_db_blob_templates = {
-    'GENE_GTF': remove_env_escape_chars( DB_OPS_FILEPATH + get_env_var('GENE_GTF_FILENAME') ),
-    'GENE_GFF': remove_env_escape_chars( DB_OPS_FILEPATH + get_env_var('GENE_GFF_FILENAME') ),
-    'GENE_IDS': remove_env_escape_chars( DB_OPS_FILEPATH + get_env_var('GENE_IDS_FILENAME') ),
-    'SVA_CSVGZ': f'{STRAIN_VARIANT_ANNOTATION_PATH.raw_string}/$SPECIES.strain-annotation.bcsq.$SVA.tsv.gz',
+    'GENE_GTF':  f'{RELEASE_FILEPATH.raw_string}/{get_env_var("GENE_GTF_FILENAME")}',
+    'GENE_GFF':  f'{RELEASE_FILEPATH.raw_string}/{get_env_var("GENE_GFF_FILENAME")}',
+    'GENE_IDS':  f'{RELEASE_FILEPATH.raw_string}/{get_env_var("GENE_IDS_FILENAME")}',
+    'SVA_CSVGZ': f'{SVA_FILEPATH.raw_string}/$SPECIES.strain-annotation.bcsq.$SVA.tsv.gz',
 }
 
 

--- a/src/pkg/caendr/caendr/services/sql/dataset/_env.py
+++ b/src/pkg/caendr/caendr/services/sql/dataset/_env.py
@@ -22,11 +22,12 @@ external_db_url_templates = {
 
 
 # Construct URL templates for internal DBs (managed by CaeNDR)
+# TODO: Keep these variables as TokenizedStrings
 internal_db_blob_templates = {
     'GENE_GTF':  f'{RELEASE_FILEPATH.raw_string}/{get_env_var("GENE_GTF_FILENAME")}',
     'GENE_GFF':  f'{RELEASE_FILEPATH.raw_string}/{get_env_var("GENE_GFF_FILENAME")}',
     'GENE_IDS':  f'{RELEASE_FILEPATH.raw_string}/{get_env_var("GENE_IDS_FILENAME")}',
-    'SVA_CSVGZ': f'{SVA_FILEPATH.raw_string}/$SPECIES.strain-annotation.bcsq.$SVA.tsv.gz',
+    'SVA_CSVGZ': f'{SVA_FILEPATH.raw_string}/{get_env_var("SVA_CSVGZ_FILENAME", as_template=True).raw_string}',
 }
 
 


### PR DESCRIPTION
## Drop tables in reverse order

Deals with `ForeignKey` dependencies.

Currently, only relevant for `Gene` and `GeneSummary`, where the former has a `ForeignKey` column into the latter.  When handling tables one at a time, they have to be populated and cleared in reverse order.


## Preflight Check

Prevents submitting ETL db-ops jobs if any required files missing in GCP.