### PR TITLE
Fix haplotype rendering

### DIFF
--- a/src/modules/site-v2/templates/_scripts/utils.js
+++ b/src/modules/site-v2/templates/_scripts/utils.js
@@ -48,6 +48,9 @@ function form_data_to_object(form_id) {
 
 function force_download(el, url) {
 
+  // If this function has run on the element already, use the href normally
+  if (el.href[el.href.length - 1] != '#') return;
+
   // Fetch the provided URL and create a blob object from it
   fetch(url)
     .then(response => response.blob())
@@ -56,14 +59,11 @@ function force_download(el, url) {
       // Create an object URL for the blob object
       const url = URL.createObjectURL(blob);
 
-      // Create a new anchor element
-      const a = document.createElement('a');
+      // Point the element's href to the URL of the new blob object
+      el.href = url;
 
-      // Set the href and download attributes for the anchor element
-      a.href = url;
-      a.download = el.download || 'download';
-
-      a.click();
+      // Re-click the element, now that the href is updated
+      el.click();
     })
 
   // Stop the first click from following the dummy link

--- a/src/modules/site-v2/templates/_scripts/utils.js
+++ b/src/modules/site-v2/templates/_scripts/utils.js
@@ -44,3 +44,28 @@ function form_data_to_object(form_id) {
   });
   return data;
 }
+
+
+function force_download(el, url) {
+
+  // Fetch the provided URL and create a blob object from it
+  fetch(url)
+    .then(response => response.blob())
+    .then(blob => {
+
+      // Create an object URL for the blob object
+      const url = URL.createObjectURL(blob);
+
+      // Create a new anchor element
+      const a = document.createElement('a');
+
+      // Set the href and download attributes for the anchor element
+      a.href = url;
+      a.download = el.download || 'download';
+
+      a.click();
+    })
+
+  // Stop the first click from following the dummy link
+  return false;
+}

--- a/src/modules/site-v2/templates/_scripts/utils.js
+++ b/src/modules/site-v2/templates/_scripts/utils.js
@@ -69,6 +69,12 @@ function force_download(e) {
   // Otherwise, stop the first click from following the link
   e.preventDefault();
 
+  // If no href provided, print an error message
+  if (!el.href) {
+    console.error('No URL provided for download.')
+    return;
+  }
+
   // Fetch the provided URL and create a blob object from it
   fetch(el.href)
     .then(response => response.blob())

--- a/src/modules/site-v2/templates/_scripts/utils.js
+++ b/src/modules/site-v2/templates/_scripts/utils.js
@@ -62,7 +62,7 @@ function force_download(e) {
   // If this function has run on the element already (i.e. references a local blob),
   // use the href normally
   if (el.href.substring(0, 5) === 'blob:') {
-    console.info('Downloading file...')
+    console.warn('Downloading file again...')
     return;
   }
 
@@ -80,7 +80,15 @@ function force_download(e) {
       // Point the element's href to the URL of the new blob object
       el.href = url;
 
-      // Re-click the element, now that the href is updated
-      el.click();
+      // Create a new anchor element to download the URL
+      // Do this instead of clicking the existing el directly to prevent any
+      // possible recursion bugs, which could spam / timeout the browser.
+      // If everything succeeds, all future clicks will use the modified href
+      // in the existing anchor element. If something fails, all clicks should
+      // restart the blob download process, which is is acceptable.
+      const a = document.createElement('a');
+      a.href = el.href;
+      a.download = el.download || 'download';
+      a.click();
     })
 }

--- a/src/modules/site-v2/templates/_scripts/utils.js
+++ b/src/modules/site-v2/templates/_scripts/utils.js
@@ -46,13 +46,24 @@ function form_data_to_object(form_id) {
 }
 
 
-function force_download(el, url) {
+function force_download(e) {
 
-  // If this function has run on the element already, use the href normally
-  if (el.href[el.href.length - 1] != '#') return;
+  // Get the current event & target element (cross-browser)
+  e = e || window.event;
+  const el = e.target || e.srcElement;
+
+  // If this function has run on the element already (i.e. references a local blob),
+  // use the href normally
+  if (el.href.substring(0, 5) === 'blob:') {
+    console.info('Downloading file...')
+    return;
+  }
+
+  // Otherwise, stop the first click from following the link
+  e.preventDefault();
 
   // Fetch the provided URL and create a blob object from it
-  fetch(url)
+  fetch(el.href)
     .then(response => response.blob())
     .then(blob => {
 
@@ -65,7 +76,4 @@ function force_download(el, url) {
       // Re-click the element, now that the href is updated
       el.click();
     })
-
-  // Stop the first click from following the dummy link
-  return false;
 }

--- a/src/modules/site-v2/templates/_scripts/utils.js
+++ b/src/modules/site-v2/templates/_scripts/utils.js
@@ -46,6 +46,13 @@ function form_data_to_object(form_id) {
 }
 
 
+/* Force a link to download a file
+ *
+ * Intercepts the initial click, fetches the URL in the href attribute as a blob,
+ * points the link to the new blob, and simulates a new click.
+ *
+ * All future clicks are allowed to use the new blob link directly.
+ */
 function force_download(e) {
 
   // Get the current event & target element (cross-browser)

--- a/src/modules/site-v2/templates/data/releases.html
+++ b/src/modules/site-v2/templates/data/releases.html
@@ -33,8 +33,10 @@
 
 
 {% block script %}
-
 <script>
+{% include '_scripts/utils.js' %}  {#/* defines: force_download */#}
+
+
 $(document).ready(function() {
 
     (function($) {
@@ -52,6 +54,7 @@ $(document).ready(function() {
     }(jQuery));
 
 });
+
 
 $(document).ready(function() {
 
@@ -72,8 +75,5 @@ $(document).ready(function() {
 });
 
 
-
 </script>
-
 {% endblock %}
-

--- a/src/modules/site-v2/templates/data/v2.html
+++ b/src/modules/site-v2/templates/data/v2.html
@@ -292,8 +292,7 @@
                                                     <i>et al.</i></a></td>
                                             <td>
                                                 {% if files.get('haplotype_png') %}
-                                                <a href="#"
-                                                    onclick="return force_download(this, '{{ files.get('haplotype_png') }}')"
+                                                <a href="{{ files.get('haplotype_png') }}" onclick="force_download(event)"
                                                     download="{{release_version}}_{{species.name}}_haplotype.png"
                                                 > haplotype.png </a>
                                                 {% else %}
@@ -441,8 +440,7 @@
                             </figure>
                             {% if files.get('haplotype_png') %}
                                 <br />
-                                <a href="#"
-                                    onclick="return force_download(this, '{{ files.get('haplotype_png') }}')"
+                                <a href="{{ files.get('haplotype_png') }}" onclick="force_download(event)"
                                     download="{{release_version}}_{{species.name}}_haplotype.png"
                                 >
                                     Download as PNG

--- a/src/modules/site-v2/templates/data/v2.html
+++ b/src/modules/site-v2/templates/data/v2.html
@@ -292,7 +292,10 @@
                                                     <i>et al.</i></a></td>
                                             <td>
                                                 {% if files.get('haplotype_png') %}
-                                                <a href="{{ files.get('haplotype_png') }}?response-content-disposition=attachment"> haplotype.png </a>
+                                                <a href="#"
+                                                    onclick="return force_download(this, '{{ files.get('haplotype_png') }}')"
+                                                    download="{{release_version}}_{{species.name}}_haplotype.png"
+                                                > haplotype.png </a>
                                                 {% else %}
                                                 haplotype.png is not included in this release
                                                 {% endif %}
@@ -433,12 +436,15 @@
                             <figure class="figure">
                                 <img class="img-fluid" src="{{ files.get('haplotype_png') }}" style="height: 450px; width: auto;">
                                 <figcaption class="text-center">
-                                    <a href="{{ files.get('haplotype_png') }}?response-content-disposition=inline" target="_blank">Click to open full-sized in a new window</a>
+                                    <a href="{{ files.get('haplotype_png') }}" target="_blank">Click to open full-sized in a new window</a>
                                 </figcaption>
                             </figure>
                             {% if files.get('haplotype_png') %}
                                 <br />
-                                <a href="{{ files.get('haplotype_png') }}?response-content-disposition=attachment" download>
+                                <a href="#"
+                                    onclick="return force_download(this, '{{ files.get('haplotype_png') }}')"
+                                    download="{{release_version}}_{{species.name}}_haplotype.png"
+                                >
                                     Download as PNG
                                 </a>
                             {% endif %}


### PR DESCRIPTION
Differentiate "view in new tab" and "download" functionality with `force_download` util function.