### PR TITLE
Fix BAM/BAI downloads

### DIFF
--- a/env/development/global.env
+++ b/env/development/global.env
@@ -35,6 +35,10 @@ GOOGLE_STORAGE_SERVICE_ACCOUNT_NAME=caendr-dev-google-storage
 MODULE_MAINTENANCE_CONTAINER_NAME=caendr-maintenance
 MODULE_MAINTENANCE_CONTAINER_VERSION=v0.0.1
 
+BAM_BAI_PREFIX=bam/{SPECIES}
+BAM_BAI_DOWNLOAD_SCRIPT_NAME={RELEASE}_{SPECIES}_bam_bai_download.sh
+
+
 ###########################################################################
 #                        Site Module Properties                           #
 ###########################################################################

--- a/env/main/global.env
+++ b/env/main/global.env
@@ -35,6 +35,10 @@ GOOGLE_STORAGE_SERVICE_ACCOUNT_NAME=caendr-google-storage
 MODULE_MAINTENANCE_CONTAINER_NAME=caendr-maintenance
 MODULE_MAINTENANCE_CONTAINER_VERSION=v0.0.1
 
+BAM_BAI_PREFIX=bam/{SPECIES}
+BAM_BAI_DOWNLOAD_SCRIPT_NAME={RELEASE}_{SPECIES}_bam_bai_download.sh
+
+
 ###########################################################################
 #                        Site Module Properties                           #
 ###########################################################################

--- a/env/qa/global.env
+++ b/env/qa/global.env
@@ -35,6 +35,10 @@ GOOGLE_STORAGE_SERVICE_ACCOUNT_NAME=caendr-qa-google-storage
 MODULE_MAINTENANCE_CONTAINER_NAME=caendr-maintenance
 MODULE_MAINTENANCE_CONTAINER_VERSION=v0.0.1
 
+BAM_BAI_PREFIX=bam/{SPECIES}
+BAM_BAI_DOWNLOAD_SCRIPT_NAME={RELEASE}_{SPECIES}_bam_bai_download.sh
+
+
 ###########################################################################
 #                        Site Module Properties                           #
 ###########################################################################

--- a/src/modules/site-v2/base/views/data/downloads.py
+++ b/src/modules/site-v2/base/views/data/downloads.py
@@ -39,13 +39,19 @@ def download_script(release_version):
     return abort(404, description="BAM/BAI download script not found")
 
 
-@data_downloads_bp.route('/download/files/<string:strain_name>/<string:ext>')
+@data_downloads_bp.route('/download/<string:species_name>/<string:strain_name>/<string:ext>')
 @cache.memoize(60*60)
 @jwt_required()
-def download_bam_bai_file(strain_name='', ext=''):
+def download_bam_bai_file(species_name='', strain_name='', ext=''):
+
+  # Parse the species & release from the URL
+  try:
+    species = Species.get(species_name.replace('-', '_'))
+  except NotFoundError:
+    return abort(404)
 
   # Get the download link for this strain
-  signed_download_url = get_bam_bai_download_link(strain_name, ext) or ''
+  signed_download_url = get_bam_bai_download_link(species, strain_name, ext) or ''
 
   return render_template('data/download-redirect.html', **{
     'title': f'{strain_name}.{ext}',

--- a/src/modules/site-v2/base/views/data/downloads.py
+++ b/src/modules/site-v2/base/views/data/downloads.py
@@ -43,16 +43,17 @@ def download_script(release_version):
 @cache.memoize(60*60)
 @jwt_required()
 def download_bam_bai_file(strain_name='', ext=''):
-  title = f'{strain_name}.{ext}'
-  alt_parent_breadcrumb = {"title": "Data", "url": url_for('data.data')}
 
-  signed_download_url = get_bam_bai_download_link(strain_name, ext)
-  msg = 'download will begin shortly...'
-  if not signed_download_url:
-    msg = 'error fetching download link'
-    signed_download_url = ''
-  
-  return render_template('data/download-redirect.html', **locals())
+  # Get the download link for this strain
+  signed_download_url = get_bam_bai_download_link(strain_name, ext) or ''
+
+  return render_template('data/download-redirect.html', **{
+    'title': f'{strain_name}.{ext}',
+    'alt_parent_breadcrumb': {"title": "Data", "url": url_for('data.data')},
+
+    'signed_download_url': signed_download_url,
+    'msg': 'download will begin shortly...' if signed_download_url else 'error fetching download link',
+  })
 
 
 @data_downloads_bp.route('/download/<string:species_name>/<string:release_version>/bam-bai-download-script', methods=['GET'])

--- a/src/modules/site-v2/base/views/data/releases.py
+++ b/src/modules/site-v2/base/views/data/releases.py
@@ -25,7 +25,10 @@ from caendr.models.sql import Strain, StrainAnnotatedVariant
 from caendr.services.cloud.storage import generate_blob_url, check_blob_exists
 from caendr.services.dataset_release import get_all_dataset_releases, get_browser_tracks_path, get_release_bucket, find_dataset_release
 from caendr.models.error import NotFoundError, SpeciesUrlNameError
+from caendr.utils.env import get_env_var
 
+
+BAM_BAI_DOWNLOAD_SCRIPT_NAME = get_env_var('BAM_BAI_DOWNLOAD_SCRIPT_NAME', as_template=True)
 
 
 releases_bp = Blueprint(
@@ -132,6 +135,11 @@ def data_v02(params, files):
   return {
     'browser_tracks_path': browser_tracks_path,
     'browser_tracks_url': generate_blob_url(params['release_bucket'], browser_tracks_path),
+
+    'download_bams_name': BAM_BAI_DOWNLOAD_SCRIPT_NAME.get_string(**{
+      'SPECIES': params['species'].name,
+      'RELEASE': params['RELEASE'].version,
+    }),
   }
 
 

--- a/src/modules/site-v2/base/views/maintenance.py
+++ b/src/modules/site-v2/base/views/maintenance.py
@@ -25,6 +25,8 @@ def cleanup_cache():
   return response
   
 
+# TODO: This is out of date, since download scripts now depend on species & release.
+#       It is likely also obsolete, since the download script is now generated on-demand.
 @maintenance_bp.route('/create_bam_bai_download_script', methods=['GET'])
 def create_bam_bai_download_script():
   if not (verify_cron_req_origin(request) or user_has_role("admin")):

--- a/src/modules/site-v2/base/views/maintenance.py
+++ b/src/modules/site-v2/base/views/maintenance.py
@@ -3,8 +3,10 @@ from flask import jsonify, Blueprint, request, flash, abort, render_template
 from caendr.services.logger import logger
 
 from caendr.services.cloud.cron import verify_cron_req_origin
-from caendr.api.strain import generate_bam_bai_download_script, get_joined_strain_list
-from caendr.models.error import APIDeniedError, APIError
+from caendr.api.strain import upload_bam_bai_download_script
+from caendr.models.error import APIDeniedError, APIError, NotFoundError
+from caendr.models.datastore import Species
+from caendr.services.dataset_release import get_all_dataset_releases, find_dataset_release
 
 from base.utils.auth import user_has_role
 from base.utils.cache import delete_expired_cache
@@ -25,15 +27,22 @@ def cleanup_cache():
   return response
   
 
-# TODO: This is out of date, since download scripts now depend on species & release.
-#       It is likely also obsolete, since the download script is now generated on-demand.
-@maintenance_bp.route('/create_bam_bai_download_script', methods=['GET'])
-def create_bam_bai_download_script():
+# TODO: This is likely obsolete, since the download script is now generated on-demand.
+@maintenance_bp.route('/create_bam_bai_download_script/<string:species_name>/<string:release_version>', methods=['GET'])
+def create_bam_bai_download_script(species_name, release_version):
   if not (verify_cron_req_origin(request) or user_has_role("admin")):
     return APIError.default_handler(APIDeniedError)
 
-  joined_strain_list = get_joined_strain_list()
-  thread = Thread(target=generate_bam_bai_download_script, args={joined_strain_list: joined_strain_list})
+  # Parse the species & release from the URL
+  try:
+    species = Species.get(species_name.replace('-', '_'))
+    release = find_dataset_release(get_all_dataset_releases(order='-version', species=species.name), release_version)
+  except NotFoundError:
+    return abort(404)
+
+  # Start a thread to generate and upload the file
+  # TODO: Should this be signed or unsigned?
+  thread = Thread(target=upload_bam_bai_download_script, args={'species': species, 'release': release})
   thread.start()
 
   response = jsonify({})

--- a/src/modules/site-v2/templates/data/v2.html
+++ b/src/modules/site-v2/templates/data/v2.html
@@ -359,8 +359,12 @@
                                         <tr>
                                             <th scope="row">Download BAMs Script</th>
                                             <td>You can batch download individual strain BAMs using this script.</td>
-                                            <td class="text-center"><a class="btn btn-primary text-light"
-                                                    href="{{ url_for('data_downloads.download_script_strain_v2', release_version=release_version) }}">download_bams.sh</a>
+                                            <td class="text-center">
+                                                <a class="btn btn-primary text-light"
+                                                    href="{{ url_for('data_downloads.download_bam_bai_script', species_name=species.get_url_name(), release_version=release_version) }}"
+                                                >
+                                                    {{ download_bams_name }}
+                                                </a>
                                             </td>
                                         </tr>
                                     </tbody>

--- a/src/modules/site-v2/templates/releases/download_tab_isotype_v1.html
+++ b/src/modules/site-v2/templates/releases/download_tab_isotype_v1.html
@@ -109,7 +109,7 @@
             <td>
             {% for strain in strains %}
                 {% if strain.isotype_ref_strain %}
-                    <a href="{{ url_for('data_downloads.download_bam_bai_file', strain_name=strain, ext='bam') }}" target="_blank"> BAM </a> / <a href="{{ url_for('data_downloads.download_bam_bai_file', strain_name=strain, ext='bam.bai') }}" target="_blank"> BAI </a>
+                    <a href="{{ url_for('data_downloads.download_bam_bai_file', species_name=species.get_url_name(), strain_name=strain, ext='bam') }}" target="_blank"> BAM </a> / <a href="{{ url_for('data_downloads.download_bam_bai_file', species_name=species.get_url_name(), strain_name=strain, ext='bam.bai') }}" target="_blank"> BAI </a>
                 {% endif %}
             {% endfor %}
             </td>

--- a/src/modules/site-v2/templates/releases/download_tab_strain_v2.html
+++ b/src/modules/site-v2/templates/releases/download_tab_strain_v2.html
@@ -42,8 +42,8 @@
                 </td>
                 <td>
                     {% if strain.sequenced %}
-                      <a href="{{ url_for('data_downloads.download_bam_bai_file', strain_name=strain, ext='bam') }}" target="_blank">BAM</a>
-                      <a href="{{ url_for('data_downloads.download_bam_bai_file', strain_name=strain, ext='bam.bai') }}" target="_blank">BAI</a>
+                      <a href="{{ url_for('data_downloads.download_bam_bai_file', species_name=species.get_url_name(), strain_name=strain, ext='bam') }}" target="_blank">BAM</a>
+                      <a href="{{ url_for('data_downloads.download_bam_bai_file', species_name=species.get_url_name(), strain_name=strain, ext='bam.bai') }}" target="_blank">BAI</a>
                     {% endif %}
                 </td>
             </tr>

--- a/src/pkg/caendr/caendr/api/strain.py
+++ b/src/pkg/caendr/caendr/api/strain.py
@@ -194,14 +194,6 @@ def fetch_bam_bai_download_script(reload=False):
   return BAM_BAI_DOWNLOAD_SCRIPT_NAME
 
 
-def get_joined_strain_list():
-  strain_listing = query_strains(is_sequenced=True)
-  joined_strain_list = ''
-  for strain in strain_listing:
-    joined_strain_list += strain.strain + ','
-  return joined_strain_list
-
-
 def generate_bam_bai_download_script(species, release, signed=False):
   '''
     Generate a Bash script that downloads all BAM/BAI files for a given species and release.

--- a/src/pkg/caendr/caendr/api/strain.py
+++ b/src/pkg/caendr/caendr/api/strain.py
@@ -12,14 +12,15 @@ from caendr.models.sql import Strain
 from caendr.services.cloud.postgresql import db, rollback_on_error
 from caendr.services.cloud.storage import get_blob, generate_download_signed_url_v4, download_blob_to_file, upload_blob_from_file, get_google_storage_credentials, generate_blob_url
 from caendr.utils.env import get_env_var
-from caendr.utils.tokens import TokenizedString
 
 MODULE_IMG_THUMB_GEN_SOURCE_PATH = get_env_var('MODULE_IMG_THUMB_GEN_SOURCE_PATH', as_template=True)
 MODULE_SITE_BUCKET_PHOTOS_NAME   = get_env_var('MODULE_SITE_BUCKET_PHOTOS_NAME')
 MODULE_SITE_BUCKET_PRIVATE_NAME  = get_env_var('MODULE_SITE_BUCKET_PRIVATE_NAME')
 
-BAM_BAI_DOWNLOAD_SCRIPT_NAME = TokenizedString("${RELEASE}_${SPECIES}_bam_bai_download.sh")
-BAM_BAI_PREFIX = TokenizedString('bam/${SPECIES}')
+BAM_BAI_DOWNLOAD_SCRIPT_NAME     = get_env_var('BAM_BAI_DOWNLOAD_SCRIPT_NAME', as_template=True)
+BAM_BAI_PREFIX                   = get_env_var('BAM_BAI_PREFIX', as_template=True)
+
+# TODO: This is still here so functions that haven't been updated will still work.
 bam_prefix = 'bam/c_elegans'
 
 
@@ -162,6 +163,7 @@ def get_bam_bai_download_link(strain_name, ext):
   return generate_download_signed_url_v4(bucket_name, blob_name)
 
 
+# TODO: This is now out of date, since script name relies on species & release
 def fetch_bam_bai_download_script(reload=False):
   if reload and os.path.exists(BAM_BAI_DOWNLOAD_SCRIPT_NAME):
     os.remove(BAM_BAI_DOWNLOAD_SCRIPT_NAME)
@@ -255,6 +257,11 @@ def upload_bam_bai_download_script(joined_strain_list, species, release):
   '''
 
   filename = BAM_BAI_DOWNLOAD_SCRIPT_NAME.get_string(**{
+    'SPECIES': species.name,
+    'RELEASE': release.version,
+  })
+
+  bam_prefix = BAM_BAI_PREFIX.get_string(**{
     'SPECIES': species.name,
     'RELEASE': release.version,
   })

--- a/src/pkg/caendr/caendr/api/strain.py
+++ b/src/pkg/caendr/caendr/api/strain.py
@@ -157,10 +157,26 @@ def get_strain_img_url(strain_name, species, thumbnail=True):
     return None
 
 
-def get_bam_bai_download_link(strain_name, ext):
-  blob_name = f'{bam_prefix}/{strain_name}.{ext}'
+def get_bam_bai_download_link(species, strain_name, ext, signed=False):
+  '''
+    Get the URL to download a BAM or BAI file for a given strain.
+
+    Args:
+      species: The Species object that this strain is under
+      strain_name: The name of the strain to download
+      ext: The extension of the desired file. Should be either 'bam' or 'bam.bai'.
+      signed (bool): Whether the generated URL should be signed. Defaults to False.
+  '''
+
   bucket_name = MODULE_SITE_BUCKET_PRIVATE_NAME
-  return generate_download_signed_url_v4(bucket_name, blob_name)
+  bam_prefix = BAM_BAI_PREFIX.get_string(SPECIES=species.name)
+
+  blob_name = f'{bam_prefix}/{strain_name}.{ext}'
+
+  if signed:
+    return generate_download_signed_url_v4(bucket_name, blob_name)
+  else:
+    return generate_blob_url(bucket_name, blob_name)
 
 
 # TODO: This is now out of date, since script name relies on species & release


### PR DESCRIPTION
Fixes bulk download script and individual download links.

- BAM/BAI download script is now generated on-demand under `data_downloads_bp.download_bam_bai_script`
- Download script now depends on species and release
- `BAM_BAI_DOWNLOAD_SCRIPT_NAME` and `BAM_BAI_PREFIX` are now templated environment variables, and rely on species parameter(s)
- Individual downloads now take a species parameter (makes new species available)

The original maintenance function that would generate the script daily has been updated to use new generator function, though it might be obsolete at this point.  I suspect it was originally done this way because generating the full list of signed URLs took a long time, so this would make a copy of the file available for immediate download.  Since we're no longer using signed URLs, this is no longer a concern.

Is there any use case where we would want to generate the download script (using either signed or unsigned URLs) and upload to GCP?