### PR TITLE
Small Dataset Release Fixes

### DIFF
--- a/src/modules/site-v2/templates/_includes/macros.html
+++ b/src/modules/site-v2/templates/_includes/macros.html
@@ -131,3 +131,27 @@
 {% macro render_dataTable_result_list_header(title, data_class=none, extra_classes='') %}
 <th scope="col" class='data-{% if data_class %}{{data_class}}{%else%}{{title|lower}}{%endif%} {{extra_classes}} bg-secondary bg-opacity-25'>{{title}}</th>
 {% endmacro%}
+
+
+
+{#
+  Render a file for download in a dataset release.
+
+  If the file exists, creates an anchor element linked to it. If not, prints the filename and a message.
+  Requires a dict `files` to be defined, which contains the given file ID if the file exists. Recommended to do this using "import ... with context".
+
+  Arguments:
+    file_id (str): The key of the file in `files`, if it exists.
+    file_name (str): The name of the file (used to display & as the downloaded file name)
+    force_download (bool, optional): Whether to force a download of the file on click. Requires the function force_download to be included in order to work properly.
+#}
+{%- macro render_download_link(file_id, file_name, force_download=false, line_break=true) %}
+    {%- if files.get(file_id) -%}
+        <a href="{{ files.get(file_id) }}"
+            {%- if force_download %} onclick="force_download(event)" download="{{ file_name }}" {% endif -%}
+        >{{ file_name }}</a>
+    {%- else %}
+        {{ file_name }} is not included in this release
+    {%- endif %}
+    {%- if line_break %}<br />{% endif %}
+{%- endmacro %}

--- a/src/modules/site-v2/templates/data/v2.html
+++ b/src/modules/site-v2/templates/data/v2.html
@@ -1,4 +1,6 @@
+{% from "_includes/macros.html" import render_download_link with context %}
 {% set file_prefix = release_version + '_' + species.name %}
+
 <div class="row">
     <div class="col mt-3">
         <nav>
@@ -106,41 +108,25 @@
                                             <td>
                                                 <strong>All Strains</strong>
                                                 <br />
-                                                {% if files.get('soft_filter_vcf_gz') %}
-                                                <a href="{{ files['soft_filter_vcf_gz'] }}"> WI.{{ release_version
-                                                    }}.soft-filter.vcf.gz </a>
-                                                {% else %}
-                                                WI.{{ release_version }}.soft-filter.vcf.gz is not included in this
-                                                release
-                                                {% endif %}
-                                                <br />
-                                                {% if files.get('soft_filter_vcf_gz_tbi') %}
-                                                <a href="{{ files.get('soft_filter_vcf_gz_tbi') }}"> WI.{{
-                                                    release_version }}.soft-filter.vcf.gz.tbi </a>
-                                                {% else %}
-                                                WI.{{ release_version }}.soft-filter.vcf.gz.tbi is not included in this
-                                                release
-                                                {% endif %}
-                                                <br />
+                                                {{ render_download_link(
+                                                    'soft_filter_vcf_gz',
+                                                    'WI.' + release_version + '.soft-filter.vcf.gz'
+                                                ) }}
+                                                {{ render_download_link(
+                                                    'soft_filter_vcf_gz_tbi',
+                                                    'WI.' + release_version + '.soft-filter.vcf.gz.tbi'
+                                                ) }}
                                                 <br />
                                                 <strong>Isotypes</strong>
                                                 <br />
-                                                {% if files.get('soft_filter_isotype_vcf_gz') %}
-                                                <a href="{{ files.get('soft_filter_isotype_vcf_gz') }}"> WI.{{
-                                                    release_version }}.soft-filter.isotype.vcf.gz </a>
-                                                {% else %}
-                                                WI.{{ release_version }}.soft-filter.isotype.vcf.gz is not included in
-                                                this release
-                                                {% endif %}
-                                                <br />
-                                                {% if files.get('soft_filter_isotype_vcf_gz_tbi') %}
-                                                <a href="{{ files.get('soft_filter_isotype_vcf_gz_tbi') }}"> WI.{{
-                                                    release_version }}.soft-filter.isotype.vcf.gz.tbi </a>
-                                                {% else %}
-                                                WI.{{ release_version }}.soft-filter.isotype.vcf.gz.tbi is not included
-                                                in this release
-                                                {% endif %}
-                                                <br />
+                                                {{ render_download_link(
+                                                    'soft_filter_isotype_vcf_gz',
+                                                    'WI.' + release_version + '.soft-filter.isotype.vcf.gz'
+                                                ) }}
+                                                {{ render_download_link(
+                                                    'soft_filter_isotype_vcf_gz_tbi',
+                                                    'WI.' + release_version + '.soft-filter.isotype.vcf.gz.tbi'
+                                                ) }}
                                             </td>
                                         </tr>
                                         <tr>
@@ -152,41 +138,25 @@
                                             <td>
                                                 <strong>All Strains</strong>
                                                 <br />
-                                                {% if files.get('hard_filter_vcf_gz') %}
-                                                <a href="{{ files.get('hard_filter_vcf_gz') }}"> WI.{{ release_version
-                                                    }}.hard-filter.vcf.gz </a>
-                                                {% else %}
-                                                WI.{{ release_version }}.hard-filter.vcf.gz is not included in this
-                                                release
-                                                {% endif %}
-                                                <br />
-                                                {% if files.get('hard_filter_vcf_gz_tbi') %}
-                                                <a href="{{ files.get('hard_filter_vcf_gz_tbi') }}"> WI.{{
-                                                    release_version }}.hard-filter.vcf.gz.tbi </a>
-                                                {% else %}
-                                                WI.{{ release_version }}.hard-filter.vcf.gz.tbi is not included in this
-                                                release
-                                                {% endif %}
-                                                <br />
+                                                {{ render_download_link(
+                                                    'hard_filter_vcf_gz',
+                                                    'WI.' + release_version + '.hard-filter.vcf.gz'
+                                                ) }}
+                                                {{ render_download_link(
+                                                    'hard_filter_vcf_gz_tbi',
+                                                    'WI.' + release_version + '.hard-filter.vcf.gz.tbi'
+                                                ) }}
                                                 <br />
                                                 <strong>Isotypes</strong>
                                                 <br />
-                                                {% if files.get('hard_filter_isotype_vcf_gz') %}
-                                                <a href="{{ files.get('hard_filter_isotype_vcf_gz') }}"> WI.{{
-                                                    release_version }}.hard-filter.isotype.vcf.gz </a>
-                                                {% else %}
-                                                WI.{{ release_version }}.hard-filter.isotype.vcf.gz is not included in
-                                                this release
-                                                {% endif %}
-                                                <br />
-                                                {% if files.get('hard_filter_isotype_vcf_gz_tbi') %}
-                                                <a href="{{ files.get('hard_filter_isotype_vcf_gz_tbi') }}"> WI.{{
-                                                    release_version }}.hard-filter.isotype.vcf.gz.tbi </a>
-                                                {% else %}
-                                                WI.{{ release_version }}.hard-filter.isotype.vcf.gz.tbi is not included
-                                                in this release
-                                                {% endif %}
-                                                <br />
+                                                {{ render_download_link(
+                                                    'hard_filter_isotype_vcf_gz',
+                                                    'WI.' + release_version + '.hard-filter.isotype.vcf.gz'
+                                                ) }}
+                                                {{ render_download_link(
+                                                    'hard_filter_isotype_vcf_gz_tbi',
+                                                    'WI.' + release_version + '.hard-filter.isotype.vcf.gz.tbi'
+                                                ) }}
                                             </td>
                                         </tr>
                                         {% if files.get('impute_isotype_vcf_gz') %}
@@ -199,22 +169,14 @@
                                             <td>
                                                 <strong>Isotypes</strong>
                                                 <br />
-                                                {% if files.get('impute_isotype_vcf_gz') %}
-                                                <a href="{{ files.get('impute_isotype_vcf_gz') }}"> WI.{{
-                                                    release_version }}.impute.isotype.vcf.gz </a>
-                                                {% else %}
-                                                WI.{{ release_version }}.impute.isotype.vcf.gz is not included in this
-                                                release
-                                                {% endif %}
-                                                <br />
-                                                {% if files.get('impute_isotype_vcf_gz_tbi') %}
-                                                <a href="{{ files.get('impute_isotype_vcf_gz_tbi') }}"> WI.{{
-                                                    release_version }}.impute.isotype.vcf.gz.tbi </a>
-                                                {% else %}
-                                                WI.{{ release_version }}.impute.isotype.vcf.gz.tbi is not included in
-                                                this release
-                                                {% endif %}
-                                                <br />
+                                                {{ render_download_link(
+                                                    'impute_isotype_vcf_gz',
+                                                    'WI.' + release_version + '.impute.isotype.vcf.gz'
+                                                ) }}
+                                                {{ render_download_link(
+                                                    'impute_isotype_vcf_gz_tbi',
+                                                    'WI.' + release_version + '.impute.isotype.vcf.gz.tbi'
+                                                ) }}
                                             </td>
                                         </tr>
                                         {% endif %}
@@ -258,41 +220,25 @@
                                             <td>
                                                 <strong>All Strains</strong>
                                                 <br />
-                                                {% if files.get('hard_filter_min4_tree') %}
-                                                <a href="{{ files.get('hard_filter_min4_tree') }}"> WI.{{
-                                                    release_version }}.hard-filter.min4.tree </a>
-                                                {% else %}
-                                                WI.{{ release_version }}.hard-filter.min4.tree is not included in this
-                                                release
-                                                {% endif %}
-                                                <br />
-                                                {% if files.get('hard_filter_min4_tree_pdf') %}
-                                                <a href="{{ files.get('hard_filter_min4_tree_pdf') }}"> WI.{{
-                                                    release_version }}.hard-filter.min4.tree.pdf </a>
-                                                {% else %}
-                                                WI.{{ release_version }}.hard-filter.min4.tree.pdf is not included in
-                                                this release
-                                                {% endif %}
-                                                <br />
+                                                {{ render_download_link(
+                                                    'hard_filter_min4_tree',
+                                                    'WI.' + release_version + '.hard-filter.min4.tree'
+                                                ) }}
+                                                {{ render_download_link(
+                                                    'hard_filter_min4_tree_pdf',
+                                                    'WI.' + release_version + '.hard-filter.min4.tree.pdf'
+                                                ) }}
                                                 <br />
                                                 <strong>Isotype</strong>
                                                 <br />
-                                                {% if files.get('hard_filter_isotype_min4_tree') %}
-                                                <a href="{{ files.get('hard_filter_isotype_min4_tree') }}"> WI.{{
-                                                    release_version }}.hard-filter.isotype.min4.tree </a>
-                                                {% else %}
-                                                WI.{{ release_version }}.hard-filter.isotype.min4.tree is not included
-                                                in this release
-                                                {% endif %}
-                                                <br />
-                                                {% if files.get('hard_filter_isotype_min4_tree_pdf') %}
-                                                <a href="{{ files.get('hard_filter_isotype_min4_tree_pdf') }}"> WI.{{
-                                                    release_version }}.hard-filter.isotype.min4.tree.pdf </a>
-                                                {% else %}
-                                                WI.{{ release_version }}.hard-filter.isotype.min4.tree.pdf is not
-                                                included in this release
-                                                {% endif %}
-                                                <br />
+                                                {{ render_download_link(
+                                                    'hard_filter_isotype_min4_tree',
+                                                    'WI.' + release_version + '.hard-filter.isotype.min4.tree'
+                                                ) }}
+                                                {{ render_download_link(
+                                                    'hard_filter_isotype_min4_tree_pdf',
+                                                    'WI.' + release_version + '.hard-filter.isotype.min4.tree.pdf'
+                                                ) }}
                                             </td>
                                         </tr>
                                         <tr>
@@ -301,19 +247,8 @@
                                                     href="https://andersenlab.org/publications/2021LeeNatureEE.pdf">Lee
                                                     <i>et al.</i></a></td>
                                             <td>
-                                                {% if files.get('haplotype_png') %}
-                                                <a href="{{ files.get('haplotype_png') }}" onclick="force_download(event)"
-                                                    download="{{ file_prefix }}_haplotype.png"
-                                                > haplotype.png </a>
-                                                {% else %}
-                                                haplotype.png is not included in this release
-                                                {% endif %}
-                                                <br />
-                                                {% if files.get('haplotype_pdf') %}
-                                                <a href="{{ files.get('haplotype_pdf') }}"> haplotype.pdf </a>
-                                                {% else %}
-                                                haplotype.pdf is not included in this release
-                                                {% endif %}
+                                                {{ render_download_link('haplotype_png', 'haplotype.png', true) }}
+                                                {{ render_download_link('haplotype_pdf', 'haplotype.pdf') }}
                                             </td>
                                         </tr>
                                         <tr>
@@ -327,17 +262,8 @@
                                                     <i>et al.</i></a>. The plot shows red (swept), gray (non-swept), and
                                                 white (not classified) regions.</td>
                                             <td>
-                                                {% if files.get('sweep_pdf') %}
-                                                <a href="{{ files.get('sweep_pdf') }}"> sweep.pdf </a>
-                                                {% else %}
-                                                sweep.pdf is not included in this release
-                                                {% endif %}
-                                                <br />
-                                                {% if files.get('sweep_summary_tsv') %}
-                                                <a href="{{ files.get('sweep_summary_tsv') }}"> sweep_summary.tsv </a>
-                                                {% else %}
-                                                sweep_summary.tsv is not included in this release
-                                                {% endif %}
+                                                {{ render_download_link('sweep_pdf', 'sweep.pdf') }}
+                                                {{ render_download_link('sweep_summary_tsv', 'sweep_summary.tsv') }}
                                             </td>
                                         </tr>
                                         <tr>

--- a/src/modules/site-v2/templates/data/v2.html
+++ b/src/modules/site-v2/templates/data/v2.html
@@ -20,7 +20,7 @@
                 <button class="nav-link" id="nav-concordance-link" data-bs-toggle="tab" data-bs-target="#concordance"
                     type="button" role="tab" aria-controls="concordance" aria-selected="false">Concordance</button>
                 {% endif %}
-                {% if files.get('haplotype_pdf') %}
+                {% if files.get('haplotype_png') %}
                 <button class="nav-link" id="nav-haplotypes-link" data-bs-toggle="tab" data-bs-target="#haplotypes"
                     type="button" role="tab" aria-controls="haplotypes" aria-selected="false">Haplotypes</button>
                 {% endif %}

--- a/src/modules/site-v2/templates/data/v2.html
+++ b/src/modules/site-v2/templates/data/v2.html
@@ -234,8 +234,14 @@
                                             <td>We have performed transposon calling for a subset of isotypes as part of
                                                 <a href="https://andersenlab.org/publications/2017Laricchia.pdf">Laricchia
                                                     <i>et al.</i></a></td>
-                                            <td class="text-center"><a class="btn btn-primary text-light"
-                                                    href="https://storage.googleapis.com/andersenlab.org/publications/2017Laricchia/tes_cender.bed">tes_cender.bed</a>
+                                            <td class="text-center">
+                                                {% if files.get('transposon_calls') %}
+                                                <a class="btn btn-primary text-light" href="{{ files.get('transposon_calls') }}"
+                                                >{{ release_version }}_{{ species.name }}_transposon_calls.bed</a>
+                                                {% else %}
+                                                {{ release_version }}_{{ species.name }}_transposon_calls.bed is not
+                                                included in this release
+                                                {% endif %}
                                             </td>
                                         </tr>
                                         <tr>

--- a/src/modules/site-v2/templates/data/v2.html
+++ b/src/modules/site-v2/templates/data/v2.html
@@ -1,5 +1,6 @@
 {% from "_includes/macros.html" import render_download_link with context %}
 {% set file_prefix = release_version + '_' + species.name %}
+{% set wi_prefix   = 'WI.' + release_version %}
 
 <div class="row">
     <div class="col mt-3">
@@ -110,22 +111,22 @@
                                                 <br />
                                                 {{ render_download_link(
                                                     'soft_filter_vcf_gz',
-                                                    'WI.' + release_version + '.soft-filter.vcf.gz'
+                                                    wi_prefix + '.soft-filter.vcf.gz'
                                                 ) }}
                                                 {{ render_download_link(
                                                     'soft_filter_vcf_gz_tbi',
-                                                    'WI.' + release_version + '.soft-filter.vcf.gz.tbi'
+                                                    wi_prefix + '.soft-filter.vcf.gz.tbi'
                                                 ) }}
                                                 <br />
                                                 <strong>Isotypes</strong>
                                                 <br />
                                                 {{ render_download_link(
                                                     'soft_filter_isotype_vcf_gz',
-                                                    'WI.' + release_version + '.soft-filter.isotype.vcf.gz'
+                                                    wi_prefix + '.soft-filter.isotype.vcf.gz'
                                                 ) }}
                                                 {{ render_download_link(
                                                     'soft_filter_isotype_vcf_gz_tbi',
-                                                    'WI.' + release_version + '.soft-filter.isotype.vcf.gz.tbi'
+                                                    wi_prefix + '.soft-filter.isotype.vcf.gz.tbi'
                                                 ) }}
                                             </td>
                                         </tr>
@@ -140,22 +141,22 @@
                                                 <br />
                                                 {{ render_download_link(
                                                     'hard_filter_vcf_gz',
-                                                    'WI.' + release_version + '.hard-filter.vcf.gz'
+                                                    wi_prefix + '.hard-filter.vcf.gz'
                                                 ) }}
                                                 {{ render_download_link(
                                                     'hard_filter_vcf_gz_tbi',
-                                                    'WI.' + release_version + '.hard-filter.vcf.gz.tbi'
+                                                    wi_prefix + '.hard-filter.vcf.gz.tbi'
                                                 ) }}
                                                 <br />
                                                 <strong>Isotypes</strong>
                                                 <br />
                                                 {{ render_download_link(
                                                     'hard_filter_isotype_vcf_gz',
-                                                    'WI.' + release_version + '.hard-filter.isotype.vcf.gz'
+                                                    wi_prefix + '.hard-filter.isotype.vcf.gz'
                                                 ) }}
                                                 {{ render_download_link(
                                                     'hard_filter_isotype_vcf_gz_tbi',
-                                                    'WI.' + release_version + '.hard-filter.isotype.vcf.gz.tbi'
+                                                    wi_prefix + '.hard-filter.isotype.vcf.gz.tbi'
                                                 ) }}
                                             </td>
                                         </tr>
@@ -171,11 +172,11 @@
                                                 <br />
                                                 {{ render_download_link(
                                                     'impute_isotype_vcf_gz',
-                                                    'WI.' + release_version + '.impute.isotype.vcf.gz'
+                                                    wi_prefix + '.impute.isotype.vcf.gz'
                                                 ) }}
                                                 {{ render_download_link(
                                                     'impute_isotype_vcf_gz_tbi',
-                                                    'WI.' + release_version + '.impute.isotype.vcf.gz.tbi'
+                                                    wi_prefix + '.impute.isotype.vcf.gz.tbi'
                                                 ) }}
                                             </td>
                                         </tr>
@@ -222,22 +223,22 @@
                                                 <br />
                                                 {{ render_download_link(
                                                     'hard_filter_min4_tree',
-                                                    'WI.' + release_version + '.hard-filter.min4.tree'
+                                                    wi_prefix + '.hard-filter.min4.tree'
                                                 ) }}
                                                 {{ render_download_link(
                                                     'hard_filter_min4_tree_pdf',
-                                                    'WI.' + release_version + '.hard-filter.min4.tree.pdf'
+                                                    wi_prefix + '.hard-filter.min4.tree.pdf'
                                                 ) }}
                                                 <br />
                                                 <strong>Isotype</strong>
                                                 <br />
                                                 {{ render_download_link(
                                                     'hard_filter_isotype_min4_tree',
-                                                    'WI.' + release_version + '.hard-filter.isotype.min4.tree'
+                                                    wi_prefix + '.hard-filter.isotype.min4.tree'
                                                 ) }}
                                                 {{ render_download_link(
                                                     'hard_filter_isotype_min4_tree_pdf',
-                                                    'WI.' + release_version + '.hard-filter.isotype.min4.tree.pdf'
+                                                    wi_prefix + '.hard-filter.isotype.min4.tree.pdf'
                                                 ) }}
                                             </td>
                                         </tr>

--- a/src/modules/site-v2/templates/data/v2.html
+++ b/src/modules/site-v2/templates/data/v2.html
@@ -248,8 +248,8 @@
                                                     href="https://andersenlab.org/publications/2021LeeNatureEE.pdf">Lee
                                                     <i>et al.</i></a></td>
                                             <td>
-                                                {{ render_download_link('haplotype_png', 'haplotype.png', true) }}
-                                                {{ render_download_link('haplotype_pdf', 'haplotype.pdf') }}
+                                                {{ render_download_link('haplotype_png', file_prefix + '_haplotype.png', true) }}
+                                                {{ render_download_link('haplotype_pdf', file_prefix + '_haplotype.pdf') }}
                                             </td>
                                         </tr>
                                         <tr>
@@ -263,8 +263,8 @@
                                                     <i>et al.</i></a>. The plot shows red (swept), gray (non-swept), and
                                                 white (not classified) regions.</td>
                                             <td>
-                                                {{ render_download_link('sweep_pdf', 'sweep.pdf') }}
-                                                {{ render_download_link('sweep_summary_tsv', 'sweep_summary.tsv') }}
+                                                {{ render_download_link('sweep_pdf',         file_prefix + '_sweep.pdf') }}
+                                                {{ render_download_link('sweep_summary_tsv', file_prefix + '_sweep_summary.tsv', true) }}
                                             </td>
                                         </tr>
                                         <tr>

--- a/src/modules/site-v2/templates/data/v2.html
+++ b/src/modules/site-v2/templates/data/v2.html
@@ -1,3 +1,4 @@
+{% set file_prefix = release_version + '_' + species.name %}
 <div class="row">
     <div class="col mt-3">
         <nav>
@@ -78,7 +79,7 @@
                                             <td>Includes strain, isotype, location information, and more.</td>
                                             <td class="text-center">
                                                 <a class="btn btn-primary text-light" href="{{ url_for('request_strains.strains_data_csv', release_name = release_version, species_name = species.name, file_ext='csv') }}">
-                                                    {{release_version}}_{{species.name}}_strain_data.csv
+                                                    {{ file_prefix }}_strain_data.csv
                                                 </a>
                                             </td>
                                         </tr>
@@ -239,12 +240,11 @@
                                             {% if files.get('transposon_calls') %}
                                             <td class="text-center">
                                                 <a class="btn btn-primary text-light" href="{{ files.get('transposon_calls') }}"
-                                                >{{ release_version }}_{{ species.name }}_transposon_calls.bed</a>
+                                                >{{ file_prefix }}_transposon_calls.bed</a>
                                             </td>
                                             {% else %}
                                             <td>
-                                                {{ release_version }}_{{ species.name }}_transposon_calls.bed is not
-                                                included in this release
+                                                {{ file_prefix }}_transposon_calls.bed is not included in this release
                                             </td>
                                             {% endif %}
                                         </tr>
@@ -303,7 +303,7 @@
                                             <td>
                                                 {% if files.get('haplotype_png') %}
                                                 <a href="{{ files.get('haplotype_png') }}" onclick="force_download(event)"
-                                                    download="{{release_version}}_{{species.name}}_haplotype.png"
+                                                    download="{{ file_prefix }}_haplotype.png"
                                                 > haplotype.png </a>
                                                 {% else %}
                                                 haplotype.png is not included in this release
@@ -351,20 +351,20 @@
                                             <td>
                                                 {% if files.get('divergent_regions_strain_bed') %}
                                                 <a href="{{ files.get('divergent_regions_strain_bed') }}">
-                                                    {{ release_version }}_{{ species.name }}_divergent_regions_strain.bed
+                                                    {{ file_prefix }}_divergent_regions_strain.bed
                                                 </a>
                                                 <br />
                                                 {% endif %}
 
                                                 {% if files.get('divergent_regions_strain_bed_gz') %}
                                                 <a href="{{ files.get('divergent_regions_strain_bed_gz') }}">
-                                                    {{ release_version }}_{{ species.name }}_divergent_regions_strain.bed.gz</a>
+                                                    {{ file_prefix }}_divergent_regions_strain.bed.gz</a>
                                                 <br />
                                                 {% endif %}
 
                                                 {% if not (files.get('divergent_regions_strain_bed') or
                                                 files.get('divergent_regions_strain_bed_gz')) %}
-                                                {{ release_version }}_{{ species.name }}_divergent_regions_strain.bed is not included in this release
+                                                {{ file_prefix }}_divergent_regions_strain.bed is not included in this release
                                                 {% endif %}
                                             </td>
                                         </tr>
@@ -455,7 +455,7 @@
                             {% if files.get('haplotype_png') %}
                                 <br />
                                 <a href="{{ files.get('haplotype_png') }}" onclick="force_download(event)"
-                                    download="{{release_version}}_{{species.name}}_haplotype.png"
+                                    download="{{ file_prefix }}_haplotype.png"
                                 >
                                     Download as PNG
                                 </a>

--- a/src/modules/site-v2/templates/data/v2.html
+++ b/src/modules/site-v2/templates/data/v2.html
@@ -221,28 +221,32 @@
                                             <th scope="row">Reference Genome FASTA ({{ RELEASE.wormbase_version }})</th>
                                             <td>The reference genome build from Wormbase used for alignment and
                                                 annotation.</td>
+                                            {% if fasta_path %}
                                             <td class="text-center">
-                                                {% if fasta_path %}
                                                 <a class="btn btn-primary text-light" href="{{ fasta_path }}">{{ fasta_name }}</a>
-                                                {% else %}
-                                                Reference genome FASTA file is not included in this release
-                                                {% endif %}
                                             </td>
+                                            {% else %}
+                                            <td>
+                                                Reference genome FASTA file is not included in this release
+                                            </td>
+                                            {% endif %}
                                         </tr>
                                         <tr>
                                             <th scope="row">Transposon Calls</th>
                                             <td>We have performed transposon calling for a subset of isotypes as part of
                                                 <a href="https://andersenlab.org/publications/2017Laricchia.pdf">Laricchia
                                                     <i>et al.</i></a></td>
+                                            {% if files.get('transposon_calls') %}
                                             <td class="text-center">
-                                                {% if files.get('transposon_calls') %}
                                                 <a class="btn btn-primary text-light" href="{{ files.get('transposon_calls') }}"
                                                 >{{ release_version }}_{{ species.name }}_transposon_calls.bed</a>
-                                                {% else %}
+                                            </td>
+                                            {% else %}
+                                            <td>
                                                 {{ release_version }}_{{ species.name }}_transposon_calls.bed is not
                                                 included in this release
-                                                {% endif %}
                                             </td>
+                                            {% endif %}
                                         </tr>
                                         <tr>
                                             <th scope="row">Tree</th>

--- a/src/pkg/caendr/caendr/models/datastore/dataset_release.py
+++ b/src/pkg/caendr/caendr/models/datastore/dataset_release.py
@@ -277,7 +277,9 @@ class DatasetRelease(Entity):
     'haplotype_png':                     'haplotype/haplotype.png',
     'haplotype_pdf':                     'haplotype/haplotype.pdf',
     'sweep_pdf':                         'haplotype/sweep.pdf',
-    'sweep_summary_tsv':                 'haplotype/sweep_summary.tsv'
+    'sweep_summary_tsv':                 'haplotype/sweep_summary.tsv',
+
+    'transposon_calls':                  '${RELEASE}_${SPECIES}_transposon_calls.bed',
   }, cutoff_date=20200101)
 
   V1 = ReportType('V1', {


### PR DESCRIPTION
- Include `transposon_calls.bed` in `caendr` GCP project(s), and show download link / not included message like other files
- Make "not included" message styling match for button links and non-button links
- Fix: Hide `Haplotypes` tab unless PNG exists (was checking for PDF, based on older layout)
- Make macro to render download link / not included message
- Add standard prefix to haplotype & swept haplotype files