### PR TITLE
Small Gene Search Fixes

### DIFF
--- a/src/modules/site-v2/base/views/api/gene.py
+++ b/src/modules/site-v2/base/views/api/gene.py
@@ -25,6 +25,16 @@ api_gene_bp = Blueprint('api_gene',
 @cache.memoize(60*60)
 @jsonify_request
 def api_search_genes(query=""):
+  '''
+    Query the table for genes based on a search and an optional species.
+
+    Returns a list of results, or None for a blank query.  Gives a maximum of 10 results.
+
+    Note that if a species is selected and the query equals the gene prefix for that species,
+    this will be considered a blank query.  (Otherwise, this would return all genes.)
+  '''
+
+  # Read the query & species frim the request
   query = request.args.get('query', query)
   query = str(query).lower()
   species = request.args.get('species')
@@ -33,6 +43,10 @@ def api_search_genes(query=""):
   if species:
     species_object = SPECIES_LIST[species]
     query = remove_prefix(query, species_object['gene_prefix'].lower())
+
+  # If the query is empty, return None
+  if not query:
+    return None
 
   return sorted(search_genes(query, species=species), key=lambda x: x['gene_symbol'])
 

--- a/src/modules/site-v2/base/views/api/gene.py
+++ b/src/modules/site-v2/base/views/api/gene.py
@@ -2,7 +2,7 @@ from flask import request, Blueprint
 from caendr.services.logger import logger
 from extensions import cache
 
-from caendr.api.gene import search_genes, search_homologs, get_gene, remove_prefix
+from caendr.api.gene import search_genes, search_homologs, get_gene, remove_prefix, gene_symbol_sort_key
 from caendr.utils.json import jsonify_request
 from caendr.models.datastore import SPECIES_LIST
 
@@ -48,7 +48,9 @@ def api_search_genes(query=""):
   if not query:
     return None
 
-  return sorted(search_genes(query, species=species), key=lambda x: x['gene_symbol'])
+  # Otherwise, apply the search, sort by gene symbol, and return the first 10 results
+  gene_results = search_genes(query, species=species, limit=None)
+  return sorted( gene_results, key=lambda x: gene_symbol_sort_key(x['gene_symbol']) )[:10]
 
 
 # @api_gene_bp.route('/search/<string:query>')

--- a/src/modules/site-v2/base/views/api/gene.py
+++ b/src/modules/site-v2/base/views/api/gene.py
@@ -63,14 +63,22 @@ def api_search_genes(query=""):
 #   return (search_genes(query, species=species) + search_homologs(query, species=species))[0:10]
 
 
-@api_gene_bp.route('/search/interval/<string:gene>') # Seach for IGV Browser
+@api_gene_bp.route('/search/interval/<string:gene>')
 @cache.memoize(60*60)
 @jsonify_request
 def api_search_gene_interval(gene=None):
+  '''
+    Get the interval for a given gene. Used in IGV Browser search.
+  '''
   if gene:
     result = get_gene(gene)
     if result:
-      return {'result': [{"chromosome": result.chrom,
-              'start': result.start,
-              'end': result.end}]}
-  return {'error': 'not found'}
+      return {
+        'result': [{
+          "chromosome": result.chrom,
+          'start':      result.start,
+          'end':        result.end,
+        }]
+      }
+
+  return { 'error': 'not found' }

--- a/src/modules/site-v2/base/views/api/gene.py
+++ b/src/modules/site-v2/base/views/api/gene.py
@@ -29,9 +29,6 @@ def api_search_genes(query=""):
     Query the table for genes based on a search and an optional species.
 
     Returns a list of results, or None for a blank query.  Gives a maximum of 10 results.
-
-    Note that if a species is selected and the query equals the gene prefix for that species,
-    this will be considered a blank query.  (Otherwise, this would return all genes.)
   '''
 
   # Read the query & species frim the request
@@ -42,7 +39,11 @@ def api_search_genes(query=""):
   # If a species was provided, remove the optional species-specific gene prefix from the query
   if species:
     species_object = SPECIES_LIST[species]
-    query = remove_prefix(query, species_object['gene_prefix'].lower())
+
+    # Remove the species-specific gene prefix from the query, unless the whole query is just the prefix
+    # Want to avoid creating a blank query
+    if query != species_object['gene_prefix'].lower():
+      query = remove_prefix(query, species_object['gene_prefix'].lower())
 
   # If the query is empty, return None
   if not query:

--- a/src/modules/site-v2/templates/_scripts/gene-search.js
+++ b/src/modules/site-v2/templates/_scripts/gene-search.js
@@ -76,7 +76,14 @@ function run_gene_search(gene, species, div_ids, callback) {
     contentType: 'application/xml',
   })
   .done(function(results) {
-    if (results.length > 0) {
+
+    // Null results - query evaluated to empty
+    if (results === null) {
+      swap_fade([ load_div ]);
+    }
+
+    // If one or more results found, display to user
+    else if (results.length > 0) {
 
       // Map each gene to a set of cell values, and add to the table as <td> elements (if applicable)
       $.each(results, (i, row) => {
@@ -96,6 +103,8 @@ function run_gene_search(gene, species, div_ids, callback) {
     }
   })
   .fail(function() {
+
+    // If query returned an error, inform the user
     console.error('Gene query failed.');
     swap_fade([ load_div ], error_div);
   });

--- a/src/modules/site-v2/templates/_scripts/gene-search.js
+++ b/src/modules/site-v2/templates/_scripts/gene-search.js
@@ -6,6 +6,7 @@
  *     - table: The ID of the table element where results are stored. Required.
  *     - loading (optional): The ID of the table loading icon. Displays while gene search is running.
  *     - empty (optional): The ID of the empty message. Displays if no results are found.
+ *     - error (optional): The ID of the error message. Displays if the server returns an error code.
  */
 function prep_gene_search(gene, div_ids) {
 
@@ -16,15 +17,16 @@ function prep_gene_search(gene, div_ids) {
   const table_div = $(div_ids.table);
   const load_div  = div_ids.loading ? $(div_ids.loading) : null;
   const empty_div = div_ids.empty   ? $(div_ids.empty)   : null;
+  const error_div = div_ids.error   ? $(div_ids.error)   : null;
 
   // If gene is empty, hide all search elements
   if (gene.trim().length == 0) {
-    swap_fade([ table_div, load_div, empty_div ])
+    swap_fade([ table_div, load_div, empty_div, error_div ])
   }
 
   // If gene not empty, replace the table with the loading icon
   else {
-    swap_fade([ table_div, empty_div ], load_div);
+    swap_fade([ table_div, empty_div, error_div ], load_div);
   }
 }
 
@@ -39,6 +41,7 @@ function prep_gene_search(gene, div_ids) {
  *              NOTE: If used on a table with multiple tbody elements, will append to ALL bodies.
  *     - loading (optional): The ID of the table loading icon. Displays while gene search is running.
  *     - empty (optional): The ID of the empty message. Displays if no results are found.
+ *     - error (optional): The ID of the error message. Displays if the server returns an error code.
  *   - callback: A function to run on each returned gene:
  *       Arguments: element index & element (gene object)
  *       Return: a list of object to be placed in table cells, or null if this gene should be skipped.
@@ -57,6 +60,7 @@ function run_gene_search(gene, species, div_ids, callback) {
   const table_div = $(div_ids.table);
   const load_div  = div_ids.loading ? $(div_ids.loading) : null;
   const empty_div = div_ids.empty   ? $(div_ids.empty)   : null;
+  const error_div = div_ids.error   ? $(div_ids.error)   : null;
 
   // If no search term provided, hide both dropdown elements
   if (gene.length == 0) {
@@ -93,6 +97,7 @@ function run_gene_search(gene, species, div_ids, callback) {
   })
   .fail(function() {
     console.error('Gene query failed.');
+    swap_fade([ load_div ], error_div);
   });
 }
 

--- a/src/modules/site-v2/templates/_scripts/gene-search.js
+++ b/src/modules/site-v2/templates/_scripts/gene-search.js
@@ -2,31 +2,31 @@
  *
  * Arguments:
  *   - gene: The gene search term
- *   - div_ids: A dict containing IDs of elements used to display the search results:
- *     - table: The ID of the table element where results are stored. Required.
- *     - loading (optional): The ID of the table loading icon. Displays while gene search is running.
- *     - empty (optional): The ID of the empty message. Displays if no results are found.
- *     - error (optional): The ID of the error message. Displays if the server returns an error code.
+ *   - selectors: A dict containing selectors for the elements used to display the search results:
+ *     - table:              Selector for the table element where results are stored. Required.
+ *     - loading (optional): Selector for the table loading icon. Displays while gene search is running.
+ *     - empty (optional):   Selector the empty message. Displays if no results are found.
+ *     - error (optional):   Selector the error message. Displays if the server returns an error code.
  */
-function prep_gene_search(gene, div_ids) {
+function prep_gene_search(gene, selectors) {
 
   // Make sure table ID is provided
-  if (!div_ids.table) throw Error('Must provide table ID.');
+  if (!selectors.table) throw Error('Must provide table ID.');
 
-  // Get all relevant divs
-  const table_div = $(div_ids.table);
-  const load_div  = div_ids.loading ? $(div_ids.loading) : null;
-  const empty_div = div_ids.empty   ? $(div_ids.empty)   : null;
-  const error_div = div_ids.error   ? $(div_ids.error)   : null;
+  // Get all elements
+  const table_el = $(selectors.table);
+  const load_el  = selectors.loading ? $(selectors.loading) : null;
+  const empty_el = selectors.empty   ? $(selectors.empty)   : null;
+  const error_el = selectors.error   ? $(selectors.error)   : null;
 
   // If gene is empty, hide all search elements
   if (gene.trim().length == 0) {
-    swap_fade([ table_div, load_div, empty_div, error_div ])
+    swap_fade([ table_el, load_el, empty_el, error_el ])
   }
 
   // If gene not empty, replace the table with the loading icon
   else {
-    swap_fade([ table_div, empty_div, error_div ], load_div);
+    swap_fade([ table_el, empty_el, error_el ], load_el);
   }
 }
 
@@ -36,35 +36,36 @@ function prep_gene_search(gene, div_ids) {
  * Arguments:
  *   - gene: The gene to query for
  *   - species: The species to query for
- *   - div_ids: A dict containing IDs of elements used to display the search results:
- *     - table: The ID of the table element to store the results in. Clears & appends rows to the tbody(s) of this table.
- *              NOTE: If used on a table with multiple tbody elements, will append to ALL bodies.
- *     - loading (optional): The ID of the table loading icon. Displays while gene search is running.
- *     - empty (optional): The ID of the empty message. Displays if no results are found.
- *     - error (optional): The ID of the error message. Displays if the server returns an error code.
+ *   - selectors: A dict containing selectors for the elements used to display the search results:
+ *     - table:              Selector for the table element to store the results in.
+ *                           Clears & appends rows to the tbody(s) of this table.
+ *                             NOTE: If used on a table with multiple tbody elements, will append to ALL bodies.
+ *     - loading (optional): Selector for the table loading icon. Displays while gene search is running.
+ *     - empty (optional):   Selector the empty message. Displays if no results are found.
+ *     - error (optional):   Selector the error message. Displays if the server returns an error code.
  *   - callback: A function to run on each returned gene:
  *       Arguments: element index & element (gene object)
  *       Return: a list of object to be placed in table cells, or null if this gene should be skipped.
  */
-function run_gene_search(gene, species, div_ids, callback) {
+function run_gene_search(gene, species, selectors, callback) {
 
-  if (!div_ids.table) throw Error('Must provide table ID.');
+  if (!selectors.table) throw Error('Must provide table ID.');
 
   // Make sure all whitespace is trimmed
   gene = gene.trim();
 
   // Get the body of the table to fill out
-  const tbody = $(`${div_ids.table} > tbody`);
+  const tbody = $(`${selectors.table} > tbody`);
 
-  // Get relevant divs
-  const table_div = $(div_ids.table);
-  const load_div  = div_ids.loading ? $(div_ids.loading) : null;
-  const empty_div = div_ids.empty   ? $(div_ids.empty)   : null;
-  const error_div = div_ids.error   ? $(div_ids.error)   : null;
+  // Get all elements
+  const table_el = $(selectors.table);
+  const load_el  = selectors.loading ? $(selectors.loading) : null;
+  const empty_el = selectors.empty   ? $(selectors.empty)   : null;
+  const error_el = selectors.error   ? $(selectors.error)   : null;
 
   // If no search term provided, hide both dropdown elements
   if (gene.length == 0) {
-    swap_fade([ table_div, load_div ])
+    swap_fade([ table_el, load_el ])
     return;
   }
 
@@ -79,7 +80,7 @@ function run_gene_search(gene, species, div_ids, callback) {
 
     // Null results - query evaluated to empty
     if (results === null) {
-      swap_fade([ load_div ]);
+      swap_fade([ load_el ]);
     }
 
     // If one or more results found, display to user
@@ -94,19 +95,19 @@ function run_gene_search(gene, species, div_ids, callback) {
       });
 
       // Hide the loading symbol & show the table
-      swap_fade([ load_div ], table_div)
+      swap_fade([ load_el ], table_el)
     }
 
     // If no results found, inform the user
     else {
-      swap_fade([ load_div ], empty_div)
+      swap_fade([ load_el ], empty_el)
     }
   })
   .fail(function() {
 
     // If query returned an error, inform the user
     console.error('Gene query failed.');
-    swap_fade([ load_div ], error_div);
+    swap_fade([ load_el ], error_el);
   });
 }
 
@@ -120,7 +121,7 @@ async function swap_fade(from, to = null) {
 
   // Filter out nulls, then wait for all elements to fade out
   await Promise.all(
-    from.filter( p => p !== null ).map( el => el.fadeOut().promise() )
+    from.filter( el => el !== null ).map( el => el.fadeOut().promise() )
   );
 
   // If provided, fade in the target element

--- a/src/modules/site-v2/templates/_scripts/igv-browser.js
+++ b/src/modules/site-v2/templates/_scripts/igv-browser.js
@@ -69,7 +69,9 @@ function add_track(track_name, track_data = null) {
   if (!tracks.has(track_name)) {
     const track = track_data || get_track(track_name)
     tracks.add(track_name);
-    return igv.getBrowser().loadTrack(track);
+    return igv.getBrowser().loadTrack(track).catch(error => {
+      console.log('Error loading track ' + track_name + ': ', error)
+    });
   }
 }
 

--- a/src/modules/site-v2/templates/tools/genome_browser/gbrowser.html
+++ b/src/modules/site-v2/templates/tools/genome_browser/gbrowser.html
@@ -69,10 +69,10 @@
                 </thead>
                 <tbody id="orthologs"></tbody>
               </table>
-              <div id="g-search-table-empty" style="display:none;">
+              <div id="g-search-table-empty" class="m-2" style="display:none;">
                 That gene name is not found in this species, so either that gene does not exist in this species or a different gene name is indexed.
               </div>
-              <div id="g-search-table-error" style="display:none;">
+              <div id="g-search-table-error" class="m-2" style="display:none;">
                 There was an error processing your gene search.
               </div>
             </div>

--- a/src/modules/site-v2/templates/tools/genome_browser/gbrowser.html
+++ b/src/modules/site-v2/templates/tools/genome_browser/gbrowser.html
@@ -69,7 +69,7 @@
                 </thead>
                 <tbody id="orthologs"></tbody>
               </table>
-              <div id="g-search-table-no-results" style="display:none;">
+              <div id="g-search-table-empty" style="display:none;">
                 That gene name is not found in this species, so either that gene does not exist in this species or a different gene name is indexed.
               </div>
             </div>
@@ -236,6 +236,13 @@ const default_checked_tracks = [
   {% for track in default_tracks %} {% if track.checked %} "{{ track.name }}", {% endif %} {% endfor %}
 ];
 
+// Divs used by the gene search
+const gene_search_div_ids = {
+  "table":   "#g-search-table",
+  "loading": "#loading-search-table",
+  "empty":   "#g-search-table-empty",
+}
+
 
 
 /* Initialization */
@@ -285,7 +292,7 @@ $(document).ready(function () {
   $("#gene-search").on("input", function(e) {
 
     var gene = $('#gene-search').val().trim();
-    prep_gene_search(gene, "#g-search-table", "#loading-search-table");
+    prep_gene_search(gene, gene_search_div_ids);
 
     clearTimeout(typingTimer);
     typingTimer = setTimeout(process_gene_search, doneTypingInterval);
@@ -423,7 +430,7 @@ function update_species(species_id) {
 function process_gene_search() {
   var gene = $('#gene-search').val().trim();
 
-  run_gene_search(gene, species, "#g-search-table", "#loading-search-table", (i, row) => {
+  run_gene_search(gene, species, gene_search_div_ids, (i, row) => {
     link = ("chrom" in row) ? format_locus_string(row["chrom"], row["start"], row["end"]) : row["locus"];
     gene_name = `<a onclick="set_position('${link}')" link='${link}' class='ortholink'>${row["locus"]}</a>`;
     return [ gene_name, row["gene_symbol"] ];

--- a/src/modules/site-v2/templates/tools/genome_browser/gbrowser.html
+++ b/src/modules/site-v2/templates/tools/genome_browser/gbrowser.html
@@ -72,6 +72,9 @@
               <div id="g-search-table-empty" style="display:none;">
                 That gene name is not found in this species, so either that gene does not exist in this species or a different gene name is indexed.
               </div>
+              <div id="g-search-table-error" style="display:none;">
+                There was an error processing your gene search.
+              </div>
             </div>
           </div>
         </div>
@@ -241,6 +244,7 @@ const gene_search_div_ids = {
   "table":   "#g-search-table",
   "loading": "#loading-search-table",
   "empty":   "#g-search-table-empty",
+  "error":   "#g-search-table-error",
 }
 
 

--- a/src/modules/site-v2/templates/tools/genome_browser/gbrowser.html
+++ b/src/modules/site-v2/templates/tools/genome_browser/gbrowser.html
@@ -240,7 +240,7 @@ const default_checked_tracks = [
 ];
 
 // Divs used by the gene search
-const gene_search_div_ids = {
+const gene_search_selectors = {
   "table":   "#g-search-table",
   "loading": "#loading-search-table",
   "empty":   "#g-search-table-empty",
@@ -296,7 +296,7 @@ $(document).ready(function () {
   $("#gene-search").on("input", function(e) {
 
     var gene = $('#gene-search').val().trim();
-    prep_gene_search(gene, gene_search_div_ids);
+    prep_gene_search(gene, gene_search_selectors);
 
     clearTimeout(typingTimer);
     typingTimer = setTimeout(process_gene_search, doneTypingInterval);
@@ -434,7 +434,7 @@ function update_species(species_id) {
 function process_gene_search() {
   var gene = $('#gene-search').val().trim();
 
-  run_gene_search(gene, species, gene_search_div_ids, (i, row) => {
+  run_gene_search(gene, species, gene_search_selectors, (i, row) => {
     link = ("chrom" in row) ? format_locus_string(row["chrom"], row["start"], row["end"]) : row["locus"];
     gene_name = `<a onclick="set_position('${link}')" link='${link}' class='ortholink'>${row["locus"]}</a>`;
     return [ gene_name, row["gene_symbol"] ];

--- a/src/modules/site-v2/templates/tools/variant_annotation/vbrowser.html
+++ b/src/modules/site-v2/templates/tools/variant_annotation/vbrowser.html
@@ -71,6 +71,9 @@
               <div id="v-search-table-empty" style="display:none;">
                 That gene name is not found in this species, so either that gene does not exist in this species or a different gene name is indexed.
               </div>
+              <div id="v-search-table-error" style="display:none;">
+                There was an error processing your gene search.
+              </div>
             </div>
           </div>
         </div>
@@ -279,6 +282,7 @@ const gene_search_div_ids = {
   "table":   "#v-search-table",
   "loading": "#loading-search-table",
   "empty":   "#v-search-table-empty",
+  "error":   "#v-search-table-error",
 }
 
 

--- a/src/modules/site-v2/templates/tools/variant_annotation/vbrowser.html
+++ b/src/modules/site-v2/templates/tools/variant_annotation/vbrowser.html
@@ -68,7 +68,7 @@
                 </thead>
                 <tbody id="orthologs"></tbody>
               </table>
-              <div id="v-search-table-no-results" style="display:none;">
+              <div id="v-search-table-empty" style="display:none;">
                 That gene name is not found in this species, so either that gene does not exist in this species or a different gene name is indexed.
               </div>
             </div>
@@ -274,6 +274,13 @@ const columnList = JSON.parse('{{ columns | tojson }}');
 
 const strainListing = JSON.parse('{{ strain_listing | tojson }}');
 
+// Divs used by the gene search
+const gene_search_div_ids = {
+  "table":   "#v-search-table",
+  "loading": "#loading-search-table",
+  "empty":   "#v-search-table-empty",
+}
+
 
 
 /* Species */
@@ -386,7 +393,7 @@ function onDownload() {
 function process_gene_search() {
   let gene = $('#gene-search').val().trim();
 
-  run_gene_search(gene, species, "#v-search-table", "#loading-search-table", (i, gene) => {
+  run_gene_search(gene, species, gene_search_div_ids, (i, gene) => {
     if (!gene["chrom"] || !gene["start"] || !gene["end"]) return null;
     const position = format_locus_string(gene["chrom"], gene["start"], gene["end"]);
     const link = `<a onclick="set_position('${position}')" link='${position}' class='ortholink'>${gene['gene_id']}</a>`;
@@ -719,7 +726,7 @@ $(document).ready(function() {
     $("#gene-search").on("input", function(e) {
 
       var gene = $('#gene-search').val().trim();
-      prep_gene_search(gene, "#v-search-table", "#loading-search-table");
+      prep_gene_search(gene, gene_search_div_ids);
 
       clearTimeout(typingTimer);
       typingTimer = setTimeout(process_gene_search, doneTypingInterval);

--- a/src/modules/site-v2/templates/tools/variant_annotation/vbrowser.html
+++ b/src/modules/site-v2/templates/tools/variant_annotation/vbrowser.html
@@ -68,10 +68,10 @@
                 </thead>
                 <tbody id="orthologs"></tbody>
               </table>
-              <div id="v-search-table-empty" style="display:none;">
+              <div id="v-search-table-empty" class="m-2" style="display:none;">
                 That gene name is not found in this species, so either that gene does not exist in this species or a different gene name is indexed.
               </div>
-              <div id="v-search-table-error" style="display:none;">
+              <div id="v-search-table-error" class="m-2" style="display:none;">
                 There was an error processing your gene search.
               </div>
             </div>

--- a/src/modules/site-v2/templates/tools/variant_annotation/vbrowser.html
+++ b/src/modules/site-v2/templates/tools/variant_annotation/vbrowser.html
@@ -278,7 +278,7 @@ const columnList = JSON.parse('{{ columns | tojson }}');
 const strainListing = JSON.parse('{{ strain_listing | tojson }}');
 
 // Divs used by the gene search
-const gene_search_div_ids = {
+const gene_search_selectors = {
   "table":   "#v-search-table",
   "loading": "#loading-search-table",
   "empty":   "#v-search-table-empty",
@@ -397,7 +397,7 @@ function onDownload() {
 function process_gene_search() {
   let gene = $('#gene-search').val().trim();
 
-  run_gene_search(gene, species, gene_search_div_ids, (i, gene) => {
+  run_gene_search(gene, species, gene_search_selectors, (i, gene) => {
     if (!gene["chrom"] || !gene["start"] || !gene["end"]) return null;
     const position = format_locus_string(gene["chrom"], gene["start"], gene["end"]);
     const link = `<a onclick="set_position('${position}')" link='${position}' class='ortholink'>${gene['gene_id']}</a>`;
@@ -730,7 +730,7 @@ $(document).ready(function() {
     $("#gene-search").on("input", function(e) {
 
       var gene = $('#gene-search').val().trim();
-      prep_gene_search(gene, gene_search_div_ids);
+      prep_gene_search(gene, gene_search_selectors);
 
       clearTimeout(typingTimer);
       typingTimer = setTimeout(process_gene_search, doneTypingInterval);


### PR DESCRIPTION
- Fix back-end sorting of results:
  - Use a more natural sorting algorithm (e.g. `lin-2` before `lin-10`)
  - Sort before truncating (taking top 10), so most relevant results actually appear
- If query is just species-specific gene prefix, search for it directly instead of removing it -- otherwise query would match all genes (equivalent to searching for `""`).  Otherwise, the prefix is removed from the search.
- Display error message in dropdown if query fails (distinct from empty results)
- Add small margins around dropdown messages, so they look less awkward