### PR TITLE
Minor Corrections

### DIFF
--- a/src/modules/site-v2/base/forms/forms.py
+++ b/src/modules/site-v2/base/forms/forms.py
@@ -335,6 +335,6 @@ class MappingSubmissionForm(Form):
   
 
 class StrainListForm(Form):
-  species = SpeciesSelectField(validators=[Required()], exclude_species=['c_briggsae', 'c_tropicalis'])
+  species = SpeciesSelectField(validators=[Required()])
 
 

--- a/src/modules/site-v2/templates/_includes/gbrowser-tracks-info.html
+++ b/src/modules/site-v2/templates/_includes/gbrowser-tracks-info.html
@@ -23,7 +23,6 @@
     Two divergent tracks are available:
 </p>
 <ul>
-    <li><strong>Divergent Regions Summary</strong> - Divergent region intervals and their observed frequency across wild
-        isolate strains.</li>
+    <li><strong>Divergent Regions Summary</strong> - Divergent region intervals across ANY of the wild strains are shown.</li>
     <li><strong>Divergent Regions Strain</strong> - Divergent region intervals for individual strains.</li>
 </ul>

--- a/src/modules/site-v2/templates/strain/catalog.html
+++ b/src/modules/site-v2/templates/strain/catalog.html
@@ -59,9 +59,9 @@ thead {
                                     <div class="accordion accordion-flush" id="strainSetInfoAccordion">
                                         <div class="accordion-item">
                                             <h2 class="accordion-header" id="divergentSets">
-                                                <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#divergentSets-collapse" aria-expanded="true" aria-controls="divergentSets">About Divergent Sets</button>
+                                                <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#divergentSets-collapse" aria-expanded="false" aria-controls="divergentSets">About Divergent Sets</button>
                                             </h2>
-                                            <div id="divergentSets-collapse" class="accordion-collapse collapse show" aria-labelledby="divergentSets">
+                                            <div id="divergentSets-collapse" class="accordion-collapse collapse" aria-labelledby="divergentSets">
                                                 <div class="accordion-body">
                                                     <p>The <strong>divergent set</strong> includes 12 genotypically different strains and can be used to determine broad-sense heritability after repeated independent measures of your favorite phenotype. <strong>We recommend starting with the divergent set.</strong></p>
                                                 </div>


### PR DESCRIPTION
- Genome Browser Divergent Regions Summary info
- Enable all species in Request Strains -> strain sets dropdown (now that data exists on back end)
- Close both strain sets info dropdowns by default in Request Strains page