### PR TITLE
Bugfix: Submit correct VCF versions to tools

### DIFF
--- a/src/modules/api/pipeline-task/pipelines/db_op.py
+++ b/src/modules/api/pipeline-task/pipelines/db_op.py
@@ -1,30 +1,27 @@
-import os
-import logging
-
 from caendr.utils import monitor
 from caendr.models.task import DatabaseOperationTask
 from caendr.models.datastore import DatabaseOperation
 from caendr.services.cloud.lifesciences import start_pipeline
 from caendr.models.lifesciences import ServiceAccount, VirtualMachine, Resources, Action, Pipeline, Request
-from caendr.utils.json import get_json_from_class
+from caendr.utils.env import get_env_var
 
 monitor.init_sentry("pipelines-task")
 
 
-GOOGLE_CLOUD_PROJECT_ID = os.environ.get('GOOGLE_CLOUD_PROJECT_ID')
-GOOGLE_CLOUD_REGION = os.environ.get('GOOGLE_CLOUD_REGION')
+# Project Environment Variables
+GOOGLE_CLOUD_PROJECT_ID = get_env_var('GOOGLE_CLOUD_PROJECT_ID')
+GOOGLE_CLOUD_REGION     = get_env_var('GOOGLE_CLOUD_REGION')
 
-MODULE_API_PIPELINE_TASK_SERVICE_ACCOUNT_NAME = os.environ.get('MODULE_API_PIPELINE_TASK_SERVICE_ACCOUNT_NAME')
-
-MODULE_API_PIPELINE_TASK_PUB_SUB_TOPIC_NAME = os.environ.get('MODULE_API_PIPELINE_TASK_PUB_SUB_TOPIC_NAME')
-
-
-sa_email = f"{MODULE_API_PIPELINE_TASK_SERVICE_ACCOUNT_NAME}@{GOOGLE_CLOUD_PROJECT_ID}.iam.gserviceaccount.com"
-pub_sub_topic = f'projects/{GOOGLE_CLOUD_PROJECT_ID}/topics/{MODULE_API_PIPELINE_TASK_PUB_SUB_TOPIC_NAME}'
+# Module Environment Variables
+SERVICE_ACCOUNT_NAME    = get_env_var('MODULE_API_PIPELINE_TASK_SERVICE_ACCOUNT_NAME')
+PUB_SUB_TOPIC_NAME      = get_env_var('MODULE_API_PIPELINE_TASK_PUB_SUB_TOPIC_NAME')
 
 
-COMMAND = '/db_operations/run.sh'
+sa_email = f"{SERVICE_ACCOUNT_NAME}@{GOOGLE_CLOUD_PROJECT_ID}.iam.gserviceaccount.com"
+pub_sub_topic = f'projects/{GOOGLE_CLOUD_PROJECT_ID}/topics/{PUB_SUB_TOPIC_NAME}'
 
+
+# Job Parameters
 SCOPES = ["https://www.googleapis.com/auth/cloud-platform"]
 MACHINE_TYPE = 'n1-standard-4'
 PREEMPTIBLE = False
@@ -35,6 +32,8 @@ VOLUME_NAME = 'db_op_work'
 LOCAL_WORK_PATH = '/workdir'
 BOOT_DISK_SIZE_GB = 50
 ENABLE_STACKDRIVER_MONITORING = True
+
+COMMAND = '/db_operations/run.sh'
 
 
 def start_db_op_pipeline(task: DatabaseOperationTask):

--- a/src/modules/api/pipeline-task/pipelines/db_op.py
+++ b/src/modules/api/pipeline-task/pipelines/db_op.py
@@ -43,7 +43,7 @@ def start_db_op_pipeline(task: DatabaseOperationTask):
 
 
 def _generate_db_op_pipeline(task: DatabaseOperationTask):
-  d = DatabaseOperation(task.id)
+  d = DatabaseOperation.get_ds(task.id, silent=False)
   image_uri = d.get_container().uri()
 
   container_name = f"db-op-{d.id}"

--- a/src/modules/api/pipeline-task/pipelines/heritability.py
+++ b/src/modules/api/pipeline-task/pipelines/heritability.py
@@ -5,7 +5,7 @@ import tabix
 from caendr.services.logger import logger
 
 from caendr.models.task import HeritabilityTask
-from caendr.models.datastore import HeritabilityReport
+from caendr.models.datastore import HeritabilityReport, Species
 from caendr.services.heritability_report import get_heritability_report
 from caendr.services.cloud.lifesciences import start_pipeline
 from caendr.models.lifesciences import ServiceAccount, VirtualMachine, Resources, Action, Pipeline, Request
@@ -58,8 +58,6 @@ def _generate_heritability_pipeline_req(task: HeritabilityTask):
   logger.debug(f"Using image: {image_uri} with commands: {container_commands}")
 
   # prepare args
-  # VCF_VERSION = "20210121"
-  VCF_VERSION = "20220216"
   GOOGLE_PROJECT = os.getenv("GOOGLE_CLOUD_PROJECT_ID", None)
   GOOGLE_ZONE = os.getenv("GOOGLE_CLOUD_ZONE", None)
   MODULE_SITE_BUCKET_PRIVATE_NAME = os.getenv("MODULE_SITE_BUCKET_PRIVATE_NAME", None)
@@ -92,7 +90,7 @@ def _generate_heritability_pipeline_req(task: HeritabilityTask):
     "GOOGLE_SERVICE_ACCOUNT_EMAIL": sa_email,
     "GOOGLE_PROJECT": GOOGLE_PROJECT,
     "GOOGLE_ZONE": GOOGLE_ZONE,
-    "VCF_VERSION": VCF_VERSION,
+    "VCF_VERSION": Species.get(h.species)['release_latest'],
     "TRAIT_FILE": TRAIT_FILE,
     "WORK_DIR": WORK_DIR,
     "DATA_DIR": DATA_DIR,

--- a/src/modules/api/pipeline-task/pipelines/heritability.py
+++ b/src/modules/api/pipeline-task/pipelines/heritability.py
@@ -51,7 +51,7 @@ def start_heritability_pipeline(task: HeritabilityTask):
 
 
 def _generate_heritability_pipeline_req(task: HeritabilityTask):
-  h = HeritabilityReport(task.id)
+  h = HeritabilityReport.get_ds(task.id, silent=False)
   
   image_uri = h.get_container().uri()
   container_commands = _get_container_commands(task.container_version)

--- a/src/modules/api/pipeline-task/pipelines/heritability.py
+++ b/src/modules/api/pipeline-task/pipelines/heritability.py
@@ -1,28 +1,33 @@
-import os
 import json
-import logging
-import tabix
 from caendr.services.logger import logger
 
 from caendr.models.task import HeritabilityTask
 from caendr.models.datastore import HeritabilityReport, Species
-from caendr.services.heritability_report import get_heritability_report
 from caendr.services.cloud.lifesciences import start_pipeline
 from caendr.models.lifesciences import ServiceAccount, VirtualMachine, Resources, Action, Pipeline, Request
+from caendr.utils.env import get_env_var
 
 
-GOOGLE_CLOUD_PROJECT_ID = os.environ.get('GOOGLE_CLOUD_PROJECT_ID')
-GOOGLE_CLOUD_REGION = os.environ.get('GOOGLE_CLOUD_REGION')
-GOOGLE_CLOUD_ZONE = os.environ.get('GOOGLE_CLOUD_ZONE')
+# Project Environment Variables
+GOOGLE_CLOUD_PROJECT_ID = get_env_var('GOOGLE_CLOUD_PROJECT_ID')
+GOOGLE_CLOUD_REGION     = get_env_var('GOOGLE_CLOUD_REGION')
+GOOGLE_CLOUD_ZONE       = get_env_var('GOOGLE_CLOUD_ZONE')
 
-MODULE_API_PIPELINE_TASK_SERVICE_ACCOUNT_NAME = os.environ.get('MODULE_API_PIPELINE_TASK_SERVICE_ACCOUNT_NAME')
-MODULE_API_PIPELINE_TASK_PUB_SUB_TOPIC_NAME = os.environ.get('MODULE_API_PIPELINE_TASK_PUB_SUB_TOPIC_NAME')
+# Site Environment Variables
+MODULE_SITE_BUCKET_PRIVATE_NAME = get_env_var("MODULE_SITE_BUCKET_PRIVATE_NAME")
+
+# Module Environment Variables
+SERVICE_ACCOUNT_NAME    = get_env_var('MODULE_API_PIPELINE_TASK_SERVICE_ACCOUNT_NAME')
+PUB_SUB_TOPIC_NAME      = get_env_var('MODULE_API_PIPELINE_TASK_PUB_SUB_TOPIC_NAME')
+WORK_BUCKET_NAME        = get_env_var("MODULE_API_PIPELINE_TASK_WORK_BUCKET_NAME")
+DATA_BUCKET_NAME        = get_env_var("MODULE_API_PIPELINE_TASK_DATA_BUCKET_NAME")
 
 
-sa_email = f"{MODULE_API_PIPELINE_TASK_SERVICE_ACCOUNT_NAME}@{GOOGLE_CLOUD_PROJECT_ID}.iam.gserviceaccount.com"
-pub_sub_topic = f'projects/{GOOGLE_CLOUD_PROJECT_ID}/topics/{MODULE_API_PIPELINE_TASK_PUB_SUB_TOPIC_NAME}'
+sa_email = f"{SERVICE_ACCOUNT_NAME}@{GOOGLE_CLOUD_PROJECT_ID}.iam.gserviceaccount.com"
+pub_sub_topic = f'projects/{GOOGLE_CLOUD_PROJECT_ID}/topics/{PUB_SUB_TOPIC_NAME}'
 
 
+# Job Parameters
 SCOPES = ["https://www.googleapis.com/auth/cloud-platform"]
 MACHINE_TYPE = 'n1-standard-1'
 PREEMPTIBLE = False
@@ -54,52 +59,30 @@ def _generate_heritability_pipeline_req(task: HeritabilityTask):
   h = HeritabilityReport.get_ds(task.id, silent=False)
   
   image_uri = h.get_container().uri()
-  container_commands = _get_container_commands(task.container_version)
-  logger.debug(f"Using image: {image_uri} with commands: {container_commands}")
-
-  # prepare args
-  GOOGLE_PROJECT = os.getenv("GOOGLE_CLOUD_PROJECT_ID", None)
-  GOOGLE_ZONE = os.getenv("GOOGLE_CLOUD_ZONE", None)
-  MODULE_SITE_BUCKET_PRIVATE_NAME = os.getenv("MODULE_SITE_BUCKET_PRIVATE_NAME", None)
-  MODULE_API_PIPELINE_TASK_WORK_BUCKET_NAME = os.getenv("MODULE_API_PIPELINE_TASK_WORK_BUCKET_NAME", None)
-  MODULE_API_PIPELINE_TASK_DATA_BUCKET_NAME = os.getenv("MODULE_API_PIPELINE_TASK_DATA_BUCKET_NAME", None)
-
-  # validation
-  if GOOGLE_PROJECT is None:
-    raise Exception("Missing GOOGLE_PROJECT")
-  if GOOGLE_ZONE is None:
-    raise Exception("Missing GOOGLE_ZONE")
-  if MODULE_SITE_BUCKET_PRIVATE_NAME is None:
-    raise Exception("Missing MODULE_SITE_BUCKET_PRIVATE_NAME")
-  if MODULE_API_PIPELINE_TASK_WORK_BUCKET_NAME is None:
-    raise Exception("Missing MODULE_API_PIPELINE_TASK_WORK_BUCKET_NAME")
-  if MODULE_API_PIPELINE_TASK_DATA_BUCKET_NAME is None:
-    raise Exception("Missing MODULE_API_PIPELINE_TASK_DATA_BUCKET_NAME")
-
-
-  # GOOGLE_SERVICE_ACCOUNT_EMAIL = "mti-caendr-service-account@mti-caendr.iam.gserviceaccount.com"
   TRAIT_FILE = f"gs://{MODULE_SITE_BUCKET_PRIVATE_NAME}/reports/heritability/{h.container_version}/{h.data_hash}/data.tsv"
-  WORK_DIR   = f"gs://{MODULE_API_PIPELINE_TASK_WORK_BUCKET_NAME}/{h.data_hash}"
-  DATA_DIR   = f"gs://{MODULE_API_PIPELINE_TASK_DATA_BUCKET_NAME}/heritability"
+  WORK_DIR   = f"gs://{WORK_BUCKET_NAME}/{h.data_hash}"
+  DATA_DIR   = f"gs://{DATA_BUCKET_NAME}/heritability"
   OUTPUT_DIR = f"gs://{MODULE_SITE_BUCKET_PRIVATE_NAME}/reports/heritability/{h.container_version}/{h.data_hash}"
-
 
   # running container name. THis is NOT the image 
   container_name = f"heritability-{h.id}"
   environment = {
     "GOOGLE_SERVICE_ACCOUNT_EMAIL": sa_email,
-    "GOOGLE_PROJECT": GOOGLE_PROJECT,
-    "GOOGLE_ZONE": GOOGLE_ZONE,
+    "GOOGLE_PROJECT": GOOGLE_CLOUD_PROJECT_ID,
+    "GOOGLE_ZONE": GOOGLE_CLOUD_ZONE,
     "VCF_VERSION": Species.get(h.species)['release_latest'],
     "TRAIT_FILE": TRAIT_FILE,
     "WORK_DIR": WORK_DIR,
     "DATA_DIR": DATA_DIR,
     "OUTPUT_DIR": OUTPUT_DIR,
-    "DATA_HASH": h.data_hash, 
-    "SPECIES": h['species'], 
-    "DATA_BUCKET": h.get_bucket_name(), 
-    "DATA_BLOB_PATH": h.get_blob_path()}
+    "DATA_HASH": h.data_hash,
+    "SPECIES": h['species'],
+    "DATA_BUCKET": h.get_bucket_name(),
+    "DATA_BLOB_PATH": h.get_blob_path(),
+  }
 
+  container_commands = _get_container_commands(task.container_version)
+  logger.debug(f"Using image: {image_uri} with commands: {container_commands}")
   logger.debug(f"Environment: { json.dumps(environment) }")
 
   service_account = ServiceAccount(email=sa_email, scopes=SCOPES)

--- a/src/modules/api/pipeline-task/pipelines/indel_primer.py
+++ b/src/modules/api/pipeline-task/pipelines/indel_primer.py
@@ -41,7 +41,7 @@ def start_indel_primer_pipeline(task: IndelPrimerTask):
 
 
 def _generate_indel_primer_pipeline_req(task: IndelPrimerTask):
-  ip = IndelPrimer(task.id)
+  ip = IndelPrimer.get_ds(task.id, silent=False)
   image_uri = ip.get_container().uri()
 
   container_name = f"indel-primer-{ip.id}"

--- a/src/modules/api/pipeline-task/pipelines/indel_primer.py
+++ b/src/modules/api/pipeline-task/pipelines/indel_primer.py
@@ -1,24 +1,22 @@
-import os
-import logging
-import tabix
-
 from caendr.models.task import IndelPrimerTask
 from caendr.models.datastore import IndelPrimer
-from caendr.services.indel_primer import get_indel_primer
 from caendr.services.cloud.lifesciences import start_pipeline
 from caendr.models.lifesciences import ServiceAccount, VirtualMachine, Resources, Action, Pipeline, Request
+from caendr.utils.env import get_env_var
 
 
-GOOGLE_CLOUD_PROJECT_ID = os.environ.get('GOOGLE_CLOUD_PROJECT_ID')
-GOOGLE_CLOUD_REGION = os.environ.get('GOOGLE_CLOUD_REGION')
-GOOGLE_CLOUD_ZONE = os.environ.get('GOOGLE_CLOUD_ZONE')
+# Project Environment Variables
+GOOGLE_CLOUD_PROJECT_ID = get_env_var('GOOGLE_CLOUD_PROJECT_ID')
+GOOGLE_CLOUD_REGION     = get_env_var('GOOGLE_CLOUD_REGION')
+GOOGLE_CLOUD_ZONE       = get_env_var('GOOGLE_CLOUD_ZONE')
 
-MODULE_API_PIPELINE_TASK_SERVICE_ACCOUNT_NAME = os.environ.get('MODULE_API_PIPELINE_TASK_SERVICE_ACCOUNT_NAME')
-MODULE_API_PIPELINE_TASK_PUB_SUB_TOPIC_NAME = os.environ.get('MODULE_API_PIPELINE_TASK_PUB_SUB_TOPIC_NAME')
+# Module Environment Variables
+SERVICE_ACCOUNT_NAME    = get_env_var('MODULE_API_PIPELINE_TASK_SERVICE_ACCOUNT_NAME')
+PUB_SUB_TOPIC_NAME      = get_env_var('MODULE_API_PIPELINE_TASK_PUB_SUB_TOPIC_NAME')
 
 
-sa_email = f"{MODULE_API_PIPELINE_TASK_SERVICE_ACCOUNT_NAME}@{GOOGLE_CLOUD_PROJECT_ID}.iam.gserviceaccount.com"
-pub_sub_topic = f'projects/{GOOGLE_CLOUD_PROJECT_ID}/topics/{MODULE_API_PIPELINE_TASK_PUB_SUB_TOPIC_NAME}'
+sa_email = f"{SERVICE_ACCOUNT_NAME}@{GOOGLE_CLOUD_PROJECT_ID}.iam.gserviceaccount.com"
+pub_sub_topic = f'projects/{GOOGLE_CLOUD_PROJECT_ID}/topics/{PUB_SUB_TOPIC_NAME}'
 
 
 SCOPES = ["https://www.googleapis.com/auth/cloud-platform"]

--- a/src/modules/api/pipeline-task/pipelines/nemascan.py
+++ b/src/modules/api/pipeline-task/pipelines/nemascan.py
@@ -2,7 +2,7 @@ import os
 import logging
 
 from caendr.models.task import NemaScanTask
-from caendr.models.datastore import NemascanMapping
+from caendr.models.datastore import NemascanMapping, Species
 from caendr.services.nemascan_mapping import get_mapping
 from caendr.services.cloud.lifesciences import start_pipeline
 from caendr.models.lifesciences import ServiceAccount, VirtualMachine, Resources, Action, Pipeline, Request
@@ -57,6 +57,7 @@ def _generate_nemascan_pipeline_req(task: NemaScanTask):
     "USERNAME": m.username if m.username else None,
     "EMAIL": m.email if m.email else None,
     "SPECIES": m.species,
+    "VCF_VERSION": Species.get(m.species)['release_latest'],
     "TRAIT_FILE": trait_file,
     "OUTPUT_DIR": output_dir,
     "WORK_DIR": work_dir,

--- a/src/modules/api/pipeline-task/pipelines/nemascan.py
+++ b/src/modules/api/pipeline-task/pipelines/nemascan.py
@@ -1,27 +1,26 @@
-import os
-import logging
-
 from caendr.models.task import NemaScanTask
 from caendr.models.datastore import NemascanMapping, Species
-from caendr.services.nemascan_mapping import get_mapping
 from caendr.services.cloud.lifesciences import start_pipeline
 from caendr.models.lifesciences import ServiceAccount, VirtualMachine, Resources, Action, Pipeline, Request
-from caendr.utils.json import get_json_from_class
+from caendr.utils.env import get_env_var
 
 
-GOOGLE_CLOUD_PROJECT_ID = os.environ.get('GOOGLE_CLOUD_PROJECT_ID')
-GOOGLE_CLOUD_REGION = os.environ.get('GOOGLE_CLOUD_REGION')
-GOOGLE_CLOUD_ZONE = os.environ.get('GOOGLE_CLOUD_ZONE')
+# Project Environment Variables
+GOOGLE_CLOUD_PROJECT_ID = get_env_var('GOOGLE_CLOUD_PROJECT_ID')
+GOOGLE_CLOUD_REGION     = get_env_var('GOOGLE_CLOUD_REGION')
+GOOGLE_CLOUD_ZONE       = get_env_var('GOOGLE_CLOUD_ZONE')
 
-MODULE_API_PIPELINE_TASK_SERVICE_ACCOUNT_NAME = os.environ.get('MODULE_API_PIPELINE_TASK_SERVICE_ACCOUNT_NAME')
-MODULE_API_PIPELINE_TASK_WORK_BUCKET_NAME = os.environ.get('MODULE_API_PIPELINE_TASK_WORK_BUCKET_NAME')
-MODULE_API_PIPELINE_TASK_PUB_SUB_TOPIC_NAME = os.environ.get('MODULE_API_PIPELINE_TASK_PUB_SUB_TOPIC_NAME')
-
-
-sa_email = f"{MODULE_API_PIPELINE_TASK_SERVICE_ACCOUNT_NAME}@{GOOGLE_CLOUD_PROJECT_ID}.iam.gserviceaccount.com"
-pub_sub_topic = f'projects/{GOOGLE_CLOUD_PROJECT_ID}/topics/{MODULE_API_PIPELINE_TASK_PUB_SUB_TOPIC_NAME}'
+# Module Environment Variables
+SERVICE_ACCOUNT_NAME    = get_env_var('MODULE_API_PIPELINE_TASK_SERVICE_ACCOUNT_NAME')
+WORK_BUCKET_NAME        = get_env_var('MODULE_API_PIPELINE_TASK_WORK_BUCKET_NAME')
+PUB_SUB_TOPIC_NAME      = get_env_var('MODULE_API_PIPELINE_TASK_PUB_SUB_TOPIC_NAME')
 
 
+sa_email = f"{SERVICE_ACCOUNT_NAME}@{GOOGLE_CLOUD_PROJECT_ID}.iam.gserviceaccount.com"
+pub_sub_topic = f'projects/{GOOGLE_CLOUD_PROJECT_ID}/topics/{PUB_SUB_TOPIC_NAME}'
+
+
+# Job Parameters
 SCOPES = ["https://www.googleapis.com/auth/cloud-platform"]
 MACHINE_TYPE = 'n1-standard-1'
 PREEMPTIBLE = False
@@ -43,14 +42,12 @@ def start_nemascan_pipeline(task: NemaScanTask):
 
 def _generate_nemascan_pipeline_req(task: NemaScanTask):
   m = NemascanMapping.get_ds(task.id, silent=False)
-  image_uri = m.get_container().uri()
 
-  trait_file = f"gs://{m.get_bucket_name()}/{m.get_data_blob_path()}"
-  output_dir = f"gs://{m.get_bucket_name()}/{m.get_result_path()}"
-  work_dir = f"gs://{MODULE_API_PIPELINE_TASK_WORK_BUCKET_NAME}/{m.data_hash}"
-  data_dir = f"gs://{m.get_bucket_name()}/{m.get_input_data_path()}"
-  google_project = GOOGLE_CLOUD_PROJECT_ID
-  google_zone = GOOGLE_CLOUD_ZONE
+  image_uri  = m.get_container().uri()
+  trait_file = f"gs://{ m.get_bucket_name() }/{ m.get_data_blob_path() }"
+  output_dir = f"gs://{ m.get_bucket_name() }/{ m.get_result_path() }"
+  work_dir   = f"gs://{ WORK_BUCKET_NAME    }/{ m.data_hash }"
+  data_dir   = f"gs://{ m.get_bucket_name() }/{ m.get_input_data_path() }"
 
   container_name = f"nemascan-{m.id}"
   environment = {
@@ -62,8 +59,8 @@ def _generate_nemascan_pipeline_req(task: NemaScanTask):
     "OUTPUT_DIR": output_dir,
     "WORK_DIR": work_dir,
     "DATA_DIR": data_dir,
-    "GOOGLE_PROJECT": google_project,
-    "GOOGLE_ZONE": google_zone,
+    "GOOGLE_PROJECT": GOOGLE_CLOUD_PROJECT_ID,
+    "GOOGLE_ZONE": GOOGLE_CLOUD_ZONE,
     "GOOGLE_SERVICE_ACCOUNT_EMAIL": sa_email
   }
 

--- a/src/modules/api/pipeline-task/pipelines/nemascan.py
+++ b/src/modules/api/pipeline-task/pipelines/nemascan.py
@@ -42,7 +42,7 @@ def start_nemascan_pipeline(task: NemaScanTask):
 
 
 def _generate_nemascan_pipeline_req(task: NemaScanTask):
-  m = NemascanMapping(task.id)
+  m = NemascanMapping.get_ds(task.id, silent=False)
   image_uri = m.get_container().uri()
 
   trait_file = f"gs://{m.get_bucket_name()}/{m.get_data_blob_path()}"

--- a/src/modules/api/pipeline-task/routes/task.py
+++ b/src/modules/api/pipeline-task/routes/task.py
@@ -9,6 +9,7 @@ from pipelines.db_op import start_db_op_pipeline
 from pipelines.indel_primer import start_indel_primer_pipeline
 from pipelines.heritability import start_heritability_pipeline
 
+from caendr.models.datastore import Species
 from caendr.models.datastore.nemascan_mapping import NemascanMapping
 from caendr.models.datastore.database_operation import DatabaseOperation
 from caendr.models.datastore.indel_primer import IndelPrimer
@@ -107,7 +108,10 @@ def handle_task(payload, task_route):
 
   # If the corresponding report couldn't be found, convert to a Bad Request error
   except NotFoundError as ex:
-    raise APIBadRequestError(f'[TASK {task.id}] Could not find {task_class.kind} object wih this ID.') from ex
+    if ex.kind == Species.kind:
+      raise APIBadRequestError(f'[TASK {task.id}] {task_class.kind} task has invalid species value.') from ex
+    else:
+      raise APIBadRequestError(f'[TASK {task.id}] Could not find {task_class.kind} object wih this ID.') from ex
 
   # Intercept any other exceptions and try setting the task status to Error
   except Exception as ex_outer:

--- a/src/modules/api/pipeline-task/routes/task.py
+++ b/src/modules/api/pipeline-task/routes/task.py
@@ -95,8 +95,10 @@ def handle_task(payload, task_route):
   logger.info(f"[TASK {payload.get('id', 'no-id')}] handle_task: {task_route}")
 
   task_metadata = _get_task_metadata(task_route)
-  task_class, start_pipeline, update_status = task_metadata.values()
+  if task_metadata is None:
+    raise APIBadRequestError(f'[TASK {payload.get("id", "no-id")}] Invalid task route "{task_route}"')
 
+  task_class, start_pipeline, update_status = task_metadata.values()
   if task_class is None:
     raise APIBadRequestError(f'[TASK {payload.get("id", "no-id")}] Invalid task route "{task_route}"')
 

--- a/src/pkg/caendr/caendr/models/datastore/entity.py
+++ b/src/pkg/caendr/caendr/models/datastore/entity.py
@@ -426,7 +426,7 @@ class Entity(object):
 
 
   @classmethod
-  def get_ds(cls, name, safe=False):
+  def get_ds(cls, name, safe=False, silent=True):
     '''
       Get the Entity from datastore with the matching name.
     '''
@@ -441,3 +441,6 @@ class Entity(object):
     # If a match was found, initialize an Entity object from it
     if match is not None:
       return cls(name, safe=safe)
+
+    if not silent:
+      raise NotFoundError(cls, {'name': name})

--- a/src/pkg/caendr/caendr/models/datastore/entity.py
+++ b/src/pkg/caendr/caendr/models/datastore/entity.py
@@ -395,33 +395,22 @@ class Entity(object):
   def query_ds_not_deleted(cls, key, val, required=False):
 
     # Run query with given key and val
-
     matches = cls.query_ds(filters=[(key, '=', val)])
-
     matches = [ el for el in matches if not el['is_deleted'] ]
 
     # If no matching entities found, return None
-
     if len(matches) == 0:
-
       if required:
-
         raise NotFoundError(cls.kind, {key: val})
-
       else:
-
         return None
 
     # If exactly one entity found, return it
-
     elif len(matches) == 1:
-
       return matches[0]
 
     # If more than one entity found, raise an error
-
     else:
-
       raise NonUniqueEntity( cls.kind, key, val, matches )
 
 


### PR DESCRIPTION
When starting a Nemascan or Heritability task, get the most recent release for the given species, and include that in the environment as `VCF_VERSION`.  Should fix bug when submitting job for new species.

Also includes a few extra checks when trying to start a `Task` (most notably, ensuring the `Task` corresponds w an existing `Entity`), as well as some re-organization.  I want to do some heavier re-organizing, but I'll wait until we're focusing on the containers.