### PR TITLE
Updated strain issues template to display "no issues found" message i…

### DIFF
--- a/src/modules/site-v2/templates/releases/download_tab_strain_v2_issues.html
+++ b/src/modules/site-v2/templates/releases/download_tab_strain_v2_issues.html
@@ -1,4 +1,12 @@
 
+{% set ns = namespace(hasIssue=false) %}
+{% for strain in strain_listing_issues %}
+    {% if strain.issues == True %}
+        {% set ns.hasIssue=true %}
+    {% endif %}
+{% endfor %}
+
+{% if ns.hasIssue == true %}
 <table class="table table-hover table-condensed strain-table">
     <thead>
         <tr>
@@ -14,8 +22,6 @@
             </th>
         </tr>
     </thead>
-    <div style="height: 30px;"></div>
-        {% set count = namespace(value=0) %}
         {% for strain in strain_listing_issues %}
             {% if strain.issues == True %}
             <tr {% if strain.isotype_ref_strain %}class="success ref_strain"{% else %}class="strain"{% endif %}>
@@ -35,3 +41,9 @@
             {% endif %}
         {% endfor %}
 </table>
+
+{% else %}
+<p class="lead">There were no strain issues found in this release.</p>
+{% endif %}
+
+

--- a/src/modules/site-v2/templates/releases/download_tab_strain_v2_issues.html
+++ b/src/modules/site-v2/templates/releases/download_tab_strain_v2_issues.html
@@ -1,12 +1,12 @@
 
-{% set ns = namespace(hasIssue=false) %}
+{% set ns = namespace(hasIssue=False) %}
 {% for strain in strain_listing_issues %}
-    {% if strain.issues == True %}
-        {% set ns.hasIssue=true %}
+    {% if strain.issues %}
+        {% set ns.hasIssue=True %}
     {% endif %}
 {% endfor %}
 
-{% if ns.hasIssue == true %}
+{% if ns.hasIssue %}
 <table class="table table-hover table-condensed strain-table">
     <thead>
         <tr>


### PR DESCRIPTION
Updated the "strain issues" page template to display a "no issues found" message if there are no issues in the release. Previous template was rendering an empty table when there were no issues, which is bad for accessibility / users with screen readers.