### PR TITLE
Fix: Email notification being sent too early

### DIFF
--- a/src/pkg/caendr/caendr/services/cloud/cloudrun.py
+++ b/src/pkg/caendr/caendr/services/cloud/cloudrun.py
@@ -100,7 +100,7 @@ def get_job_execution_status(name):
 
   # TODO: Make sure this is adequate
   for condition in response['conditions']:
-    if condition['type'] == 'Completed':
+    if condition['type'] == 'Completed' and condition['state'] == 'CONDITION_SUCCEEDED':
       done = True
     if condition['state'] == 'CONDITION_FAILED':
       error = condition['message']


### PR DESCRIPTION
Fixes bug in checking for CloudRun job execution. Original check for `done` was too lax, meaning the email would be sent well before the job was done.