### PR TITLE
Fix Pub/Sub status checks (and maybe SSLEOFError once and for all)

### DIFF
--- a/src/modules/api/pipeline-task/routes/task.py
+++ b/src/modules/api/pipeline-task/routes/task.py
@@ -11,7 +11,7 @@ from caendr.models.task import TaskStatus
 from caendr.models.pub_sub import PubSubAttributes, PubSubMessage, PubSubStatus
 
 from caendr.services.cloud.task import update_task_status, verify_task_headers
-from caendr.services.cloud.pubsub import get_attribute, make_pubsub_response
+from caendr.services.cloud.pubsub import get_attribute, pubsub_endpoint
 from caendr.services.cloud.lifesciences import create_pipeline_operation_record, get_operation_id_from_name
 from caendr.services.cloud.utils import update_pipeline_operation_record, update_all_linked_status_records
 from caendr.services.persistent_logger import PersistentLogger
@@ -83,6 +83,7 @@ def start_task(task_route):
 
 
 @task_handler_bp.route('/status', methods=['POST'])
+@pubsub_endpoint
 def update_task():
 
   # Parse request payload
@@ -132,5 +133,5 @@ def update_task():
 
   # If the job has finished or errored out, acknowledge the Pub/Sub message
   # If the job is still running, don't acknowledge -- tells Pub/Sub to try the request again
-  response_status, response_code = make_pubsub_response( op['done'] or op['error'] )
-  return jsonify({'status': response_status}), response_code
+  # Return as bool value to be handled by pubsub_endpoint decorator
+  return op['done'] or op['error']

--- a/src/modules/api/pipeline-task/routes/task.py
+++ b/src/modules/api/pipeline-task/routes/task.py
@@ -11,7 +11,7 @@ from caendr.models.task import TaskStatus
 from caendr.models.pub_sub import PubSubAttributes, PubSubMessage, PubSubStatus
 
 from caendr.services.cloud.task import update_task_status, verify_task_headers
-from caendr.services.cloud.pubsub import get_attribute
+from caendr.services.cloud.pubsub import get_attribute, make_pubsub_response
 from caendr.services.cloud.lifesciences import create_pipeline_operation_record, get_operation_id_from_name
 from caendr.services.cloud.utils import update_pipeline_operation_record, update_all_linked_status_records
 from caendr.services.persistent_logger import PersistentLogger
@@ -130,4 +130,7 @@ def update_task():
     raise APIInternalError(f"Error updating status record(s)", call_id) from ex
 
 
-  return jsonify({'status': 'OK'}), 200
+  # If the job has finished or errored out, acknowledge the Pub/Sub message
+  # If the job is still running, don't acknowledge -- tells Pub/Sub to try the request again
+  response_status, response_code = make_pubsub_response( op['done'] or op['error'] )
+  return jsonify({'status': response_status}), response_code

--- a/src/pkg/caendr/caendr/services/cloud/analytics.py
+++ b/src/pkg/caendr/caendr/services/cloud/analytics.py
@@ -7,12 +7,13 @@ from oauth2client.service_account import ServiceAccountCredentials
 
 from caendr.services.cloud.secret import get_secret
 from caendr.services.cloud.service_account import get_service_account_credentials
+from caendr.utils.env import get_env_var
 
 from .discovery import use_service
 
 
 
-GOOGLE_ANALYTICS_SERVICE_ACCOUNT_NAME = os.environ.get('GOOGLE_ANALYTICS_SERVICE_ACCOUNT_NAME')
+GOOGLE_ANALYTICS_SERVICE_ACCOUNT_NAME = get_env_var('GOOGLE_ANALYTICS_SERVICE_ACCOUNT_NAME')
 
 
 

--- a/src/pkg/caendr/caendr/services/cloud/analytics.py
+++ b/src/pkg/caendr/caendr/services/cloud/analytics.py
@@ -1,6 +1,5 @@
 import os
 import json
-import googleapiclient.discovery
 import pandas as pd
 
 from datetime import datetime
@@ -9,24 +8,30 @@ from oauth2client.service_account import ServiceAccountCredentials
 from caendr.services.cloud.secret import get_secret
 from caendr.services.cloud.service_account import get_service_account_credentials
 
+from .discovery import use_service
+
+
+
 GOOGLE_ANALYTICS_SERVICE_ACCOUNT_NAME = os.environ.get('GOOGLE_ANALYTICS_SERVICE_ACCOUNT_NAME')
 
 
-def authenticate_google_analytics():
-  """ Uses service account credentials to authorize access to google analytics """
+
+def get_analytics_credentials():
+  '''
+    Helper function to get the service account credentials that authorize access to Google Analytics
+  '''
   service_credentials = get_service_account_credentials(get_secret(GOOGLE_ANALYTICS_SERVICE_ACCOUNT_NAME))
   scope = ['https://www.googleapis.com/auth/analytics.readonly']
-  credentials = ServiceAccountCredentials.from_json_keyfile_dict(service_credentials, scope)
-  return googleapiclient.discovery.build('analyticsreporting', 'v4', credentials=credentials)
+  return ServiceAccountCredentials.from_json_keyfile_dict(service_credentials, scope)
 
 
-def get_weekly_visits():
+@use_service('analyticsreporting', 'v4', credentials=get_analytics_credentials)
+def get_weekly_visits(SERVICE):
   """
       Get the number of weekly visitors
       Cached weekly
   """
-  ga = authenticate_google_analytics()
-  response = ga.reports().batchGet(
+  response = SERVICE.reports().batchGet(
     body={
       'reportRequests': [{
         'viewId': '117392266',

--- a/src/pkg/caendr/caendr/services/cloud/cloudrun.py
+++ b/src/pkg/caendr/caendr/services/cloud/cloudrun.py
@@ -1,10 +1,9 @@
-from googleapiclient import discovery
 from googleapiclient.errors import HttpError
-from oauth2client.client import GoogleCredentials
 
 from caendr.services.logger import logger
-
 from caendr.utils.env import get_env_var
+
+from .discovery import use_service
 
 
 
@@ -16,15 +15,13 @@ GOOGLE_CLOUD_ZONE           = get_env_var('GOOGLE_CLOUD_ZONE')
 SERVICE_ACCOUNT_NAME        = get_env_var('MODULE_API_PIPELINE_TASK_SERVICE_ACCOUNT_NAME')
 
 
-# Create the CloudRun service using the v2 API
-SERVICE = discovery.build('run', 'v2', credentials=GoogleCredentials.get_application_default())
-
 parent_id = f"projects/{GOOGLE_CLOUD_PROJECT_NUMBER}/locations/{GOOGLE_CLOUD_REGION}"
 sa_email  = f"{SERVICE_ACCOUNT_NAME}@{GOOGLE_CLOUD_PROJECT_ID}.iam.gserviceaccount.com"
 
 
 
-def create_job(name, task_count, timeout, max_retries, container, update_if_exists=True):
+@use_service('run', 'v2')
+def create_job(SERVICE, name, task_count, timeout, max_retries, container, update_if_exists=True):
   '''
     Create a CloudRun job.
     For more details, see https://googleapis.github.io/google-api-python-client/docs/dyn/run_v2.projects.locations.jobs.html#create
@@ -70,7 +67,8 @@ def create_job(name, task_count, timeout, max_retries, container, update_if_exis
   return SERVICE.projects().locations().jobs().create( parent=parent_id, jobId=name, body=body ).execute()
 
 
-def run_job(name):
+@use_service('run', 'v2')
+def run_job(SERVICE, name):
   '''
     Run a CloudRun job.
 
@@ -83,7 +81,8 @@ def run_job(name):
   return SERVICE.projects().locations().jobs().run( name=f'{parent_id}/jobs/{name}' ).execute()
 
 
-def get_job_execution_status(name):
+@use_service('run', 'v2')
+def get_job_execution_status(SERVICE, name):
   '''
     Retrieve the status of a job execution.
 

--- a/src/pkg/caendr/caendr/services/cloud/cloudrun.py
+++ b/src/pkg/caendr/caendr/services/cloud/cloudrun.py
@@ -97,11 +97,15 @@ def get_job_execution_status(SERVICE, name):
   done  = False
   error = None
 
-  # TODO: Make sure this is adequate
   for condition in response['conditions']:
+
+    # If the "Completed" condition succeeded, mark as done
     if condition['type'] == 'Completed' and condition['state'] == 'CONDITION_SUCCEEDED':
       done = True
+
+    # If any condition failed, mark as done and record error
     if condition['state'] == 'CONDITION_FAILED':
+      done = True
       error = condition['message']
 
   return {'done': done, 'error': error, 'response': response}

--- a/src/pkg/caendr/caendr/services/cloud/discovery.py
+++ b/src/pkg/caendr/caendr/services/cloud/discovery.py
@@ -1,0 +1,44 @@
+import functools
+from googleapiclient import discovery
+from oauth2client.client import GoogleCredentials
+
+from caendr.services.logger import logger
+
+
+
+def use_service(service_name, version, credentials=None):
+  '''
+    Decorator for functions which access a GCP service through the Google API Client library.
+
+    Builds the desired service, and injects it as the first argument to the wrapped function.
+    Closes the service after the function is run, regardless of return / raise value.
+  '''
+  def decorator(func):
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+      nonlocal service_name, version, credentials
+
+      # Get default credentials if none are provided
+      if credentials is None:
+        credentials = GoogleCredentials.get_application_default()
+
+      # Otherwise, if function provided, call it
+      elif callable(credentials):
+        credentials = credentials()
+
+      # Build the desired service
+      SERVICE = discovery.build(service_name, version, credentials=credentials)
+
+      # Try running & returning from the decorated function
+      try:
+        return func(SERVICE, *args, **kwargs)
+
+      # After function execution, ensure connections to the service are closed
+      finally:
+        try:
+          SERVICE.close()
+        except Exception as ex:
+          logger.error(f'Failed to close service {service_name} ({version}): {ex}')
+
+    return wrapper
+  return decorator

--- a/src/pkg/caendr/caendr/services/cloud/lifesciences.py
+++ b/src/pkg/caendr/caendr/services/cloud/lifesciences.py
@@ -1,8 +1,6 @@
 import os
 
 from caendr.services.logger import logger
-from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
 from caendr.models.datastore import PipelineOperation
 from caendr.models.error import PipelineRunError
@@ -10,18 +8,20 @@ from caendr.services.cloud.service_account import authenticate_google_service
 from caendr.utils.env import get_env_var
 from caendr.utils.json import get_json_from_class
 
+from .discovery import use_service
+
+
 
 GOOGLE_CLOUD_PROJECT_NUMBER = os.environ.get('GOOGLE_CLOUD_PROJECT_NUMBER')
 GOOGLE_CLOUD_REGION = os.environ.get('GOOGLE_CLOUD_REGION')
 MODULE_API_PIPELINE_TASK_SERVICE_ACCOUNT_NAME = os.environ.get('MODULE_API_PIPELINE_TASK_SERVICE_ACCOUNT_NAME')
 
-
-
 #sa_private_key_b64 = get_secret(MODULE_API_PIPELINE_TASK_SERVICE_ACCOUNT_NAME)
 #gls_service = authenticate_google_service(sa_private_key_b64, None, 'lifesciences', 'v2beta')
-gls_service = discovery.build('lifesciences', 'v2beta', credentials=GoogleCredentials.get_application_default())
+# gls_service = discovery.build('lifesciences', 'v2beta', credentials=GoogleCredentials.get_application_default())
 
 parent_id = f"projects/{GOOGLE_CLOUD_PROJECT_NUMBER}/locations/{GOOGLE_CLOUD_REGION}"
+
 
 
 def get_operation_id_from_name(operation_name):
@@ -32,12 +32,13 @@ def get_operation_id_from_name(operation_name):
     return operation_name
 
 
-def start_pipeline(task_id, pipeline_request):
+@use_service('lifesciences', 'v2beta')
+def start_pipeline(SERVICE, task_id, pipeline_request):
   req_body = get_json_from_class(pipeline_request)
   logger.debug(f'[TASK {task_id}] Starting Pipeline Request: {req_body}')
 
   try:
-    request = gls_service.projects().locations().pipelines().run(parent=parent_id, body=req_body)
+    request = SERVICE.projects().locations().pipelines().run(parent=parent_id, body=req_body)
     response = request.execute()
     logger.debug(f'[TASK {task_id}] Pipeline Response: {response}')
     return response
@@ -76,7 +77,8 @@ def create_pipeline_operation_record(task, response):
   return op
 
 
-def get_pipeline_status(operation_name):
+@use_service('lifesciences', 'v2beta')
+def get_pipeline_status(SERVICE, operation_name):
   """Return pipeline status
   Retrieves and returns the status for a pipeline
   Args:
@@ -92,7 +94,7 @@ def get_pipeline_status(operation_name):
     }
   """
   logger.debug(f'get_pipeline_status: operation_name:{operation_name}')
-  request = gls_service.projects().locations().operations().get(name=operation_name)
+  request = SERVICE.projects().locations().operations().get(name=operation_name)
   response = request.execute()
 
   id = get_operation_id_from_name(operation_name)

--- a/src/pkg/caendr/caendr/services/cloud/pubsub.py
+++ b/src/pkg/caendr/caendr/services/cloud/pubsub.py
@@ -59,3 +59,30 @@ def publish_message(SERVICE, topic, data=None, **kwargs):
   except Exception as ex:
     logger.warn(f'Couldn\'t extract message ID from Pub/Sub response: {response}. Error: {ex}')
     return None
+
+
+def make_pubsub_response(ack: bool):
+  '''
+    Create a response for a Pub/Sub push subscription, either acknowledging or not-acknowledging a message.
+
+    If the message is acknowledged, Pub/Sub will stop sending messages.
+    If not, Pub/Sub may retry the message after some period of time (based on the subscription configuration).
+
+    For information on acknowledging push messages, see https://cloud.google.com/pubsub/docs/push#receive_push.
+
+    Args:
+      - ack (bool): Whether or not to acknowledge the message.
+
+    Returns:
+      - status (str): The response status string
+      - code (int): The response code
+  '''
+
+  # To acknowledge a message, return an OK response
+  # This tells Pub/Sub to stop sending requests
+  if ack:
+    return 'OK', 200
+
+  # Otherwise, return a Continue response
+  # This counts as a NACK (not acknowledged), which tells Pub/Sub to try the request again later (if applicable)
+  return 'Continue', 100

--- a/src/pkg/caendr/caendr/services/cloud/pubsub.py
+++ b/src/pkg/caendr/caendr/services/cloud/pubsub.py
@@ -1,18 +1,14 @@
-from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
-
 from caendr.services.logger import logger
+from caendr.utils.env import get_env_var
 
 from caendr.models.error import APIUnprocessableEntity
 from caendr.models.pub_sub import PubSubStatus, PubSubMessage, PubSubAttributes
-from caendr.utils.env import get_env_var
+
+from .discovery import use_service
 
 
 
 GOOGLE_CLOUD_PROJECT_ID = get_env_var('GOOGLE_CLOUD_PROJECT_ID')
-
-# Create the Pub/Sub service
-SERVICE = discovery.build('pubsub', 'v1', credentials=GoogleCredentials.get_application_default())
 parent = f'projects/{GOOGLE_CLOUD_PROJECT_ID}'
 
 
@@ -34,7 +30,8 @@ def get_attribute(payload, key, can_be_none=False):
   return value
 
 
-def publish_message(topic, data=None, **kwargs):
+@use_service('pubsub', 'v1')
+def publish_message(SERVICE, topic, data=None, **kwargs):
   '''
     Publish a message to the specified topic.
     Arbitrary keyword args are interpreted as message attributes.

--- a/src/pkg/caendr/caendr/services/cloud/utils.py
+++ b/src/pkg/caendr/caendr/services/cloud/utils.py
@@ -99,8 +99,10 @@ def update_all_linked_status_records(kind, operation_name):
   error = status.get('error')
   if error:
     logger.error(f"[UPDATE {op_id}] Error: Kind: {kind} Operation Name: {operation_name} error: {error}")
-  if done:
-    status = TaskStatus.ERROR if error else TaskStatus.COMPLETE
+    status = TaskStatus.ERROR
+  elif done:
+    logger.debug(f"[UPDATE {op_id}] Complete: Kind: {kind} Operation Name: {operation_name}")
+    status = TaskStatus.COMPLETE
   else:
     status = TaskStatus.RUNNING
 

--- a/tf/caendr/modules/api/pipeline_task/pub-sub.tf
+++ b/tf/caendr/modules/api/pipeline_task/pub-sub.tf
@@ -27,6 +27,11 @@ resource "google_pubsub_subscription" "pipeline_task" {
     ttl = "2678400s"
   }
 
+  retry_policy {
+    minimum_backoff = "60s"
+    maximum_backoff = "300s"
+  }
+
   message_retention_duration = "259200s"
   name                       = var.module_api_pipeline_task_vars.pub_sub_subscription_name
   project                    = var.google_cloud_vars.project_id


### PR DESCRIPTION
Explicitly ack or nack a Pub/Sub message sent to the `status` endpoint, using codes `200` and `100` respectively.  This means the subscription will continue to send periodic updates until the job finishes.

Involves changing the configuration of the Subscription to wait between messages, using exponential backoff.  I tested my proposed change by manually updating Pub/Sub in GCP.  Encoding this change in Terraform would formalize it.

Also, adds a `use_service` decorator which creates a Google Client API resource on-the-fly before the function is called, and closes all connections once it finishes.  My working theory is that the `SSLEOFError` comes from stale resource connections, and that closing them will solve this issue.  Initial tests look promising, but I'll test this again tomorrow to really get a cold start scenario.

