### PR TITLE
Pull CloudRun condition state enum from Google API

### DIFF
--- a/src/modules/site-v2/requirements.txt
+++ b/src/modules/site-v2/requirements.txt
@@ -26,6 +26,7 @@ google-cloud-secret-manager
 google-cloud-storage
 google-cloud-datastore
 google_cloud_logging
+google-cloud-run
 grpcio
 gunicorn
 httplib2==0.18.0

--- a/src/pkg/caendr/caendr/services/cloud/cloudrun.py
+++ b/src/pkg/caendr/caendr/services/cloud/cloudrun.py
@@ -1,4 +1,5 @@
 from googleapiclient.errors import HttpError
+from google.cloud import run
 
 from caendr.services.logger import logger
 from caendr.utils.env import get_env_var
@@ -100,11 +101,11 @@ def get_job_execution_status(SERVICE, name):
   for condition in response['conditions']:
 
     # If the "Completed" condition succeeded, mark as done
-    if condition['type'] == 'Completed' and condition['state'] == 'CONDITION_SUCCEEDED':
+    if condition['type'] == 'Completed' and condition['state'] == run.Condition.State.CONDITION_SUCCEEDED.name:
       done = True
 
     # If any condition failed, mark as done and record error
-    if condition['state'] == 'CONDITION_FAILED':
+    if condition['state'] == run.Condition.State.CONDITION_FAILED.name:
       done = True
       error = condition['message']
 


### PR DESCRIPTION
I was able to find an enum for the Condition State (succeeded, failed, etc) in the [`google-cloud-run`](https://cloud.google.com/run/docs/reference/rest/v2/Condition#State) library.

However, the Condition type is a `string` (not an `enum`) in the [docs](https://cloud.google.com/run/docs/reference/rest/v2/Condition), and I wasn't able to find a specification that lists all the possible values...