### PR TITLE
Miscellaneous fixes (obsolete db close, API error codes, heritability report tweaks)

### DIFF
--- a/src/modules/api/pipeline-task/pipelines/utils.py
+++ b/src/modules/api/pipeline-task/pipelines/utils.py
@@ -9,7 +9,7 @@ from caendr.utils.env       import get_env_var
 from pipelines.task_handler import DatabaseOperationTaskHandler, IndelFinderTaskHandler, HeritabilityTaskHandler, NemascanTaskHandler
 
 from caendr.models.datastore             import Species
-from caendr.models.error                 import APIBadRequestError, NotFoundError
+from caendr.models.error                 import APIBadRequestError, APINotFoundError, NotFoundError
 from caendr.services.nemascan_mapping    import update_nemascan_mapping_status
 from caendr.services.database_operation  import update_db_op_status
 from caendr.services.indel_primer        import update_indel_primer_status
@@ -63,7 +63,7 @@ def get_task_handler(queue_name, *args, **kwargs):
     if ex.kind == Species.kind:
       raise APIBadRequestError(f'{ cls._Entity_Class.kind } task has invalid species value') from ex
     else:
-      raise APIBadRequestError(f'Could not find { cls._Entity_Class.kind } object wih this ID') from ex
+      raise APINotFoundError(f'Could not find { cls._Entity_Class.kind } object wih this ID') from ex
 
 
 

--- a/src/modules/api/pipeline-task/pipelines/utils.py
+++ b/src/modules/api/pipeline-task/pipelines/utils.py
@@ -1,4 +1,5 @@
 import backoff
+import json
 from googleapiclient.errors import HttpError
 from ssl import SSLEOFError
 
@@ -22,6 +23,17 @@ INDEL_PRIMER_TASK_QUEUE_NAME  = get_env_var('INDEL_PRIMER_TASK_QUEUE_NAME')
 HERITABILITY_TASK_QUEUE_NAME  = get_env_var('HERITABILITY_TASK_QUEUE_NAME')
 NEMASCAN_TASK_QUEUE_NAME      = get_env_var('NEMASCAN_TASK_QUEUE_NAME')
 
+
+
+def load_json_from_request(request):
+  '''
+    Loads the request data as JSON.
+    Raises a 400 error if the body is not valid JSON.
+  '''
+  try:
+    return json.loads(request.data)
+  except Exception as ex:
+    raise APIBadRequestError('Failed to parse request body as valid JSON') from ex
 
 
 def log_ssl_backoff(details):

--- a/src/modules/api/pipeline-task/routes/task.py
+++ b/src/modules/api/pipeline-task/routes/task.py
@@ -4,7 +4,7 @@ from flask import Blueprint, jsonify, request
 from caendr.services.logger import logger
 from caendr.utils import monitor
 
-from pipelines.utils import start_job, update_status_safe
+from pipelines.utils import start_job, update_status_safe, load_json_from_request
 
 from caendr.models.error import APIError, APIBadRequestError, APIInternalError, APIUnprocessableEntity
 from caendr.models.task import TaskStatus
@@ -30,10 +30,7 @@ def start_task(task_route):
   logger.info(f"Task: {queue}:{task}")
 
   # Parse request payload
-  try:
-    payload = json.loads(request.data)
-  except:
-    raise APIUnprocessableEntity('Failed to parse request body as valid JSON')
+  payload = load_json_from_request(request)
 
   # Get the task ID from the payload
   op_id = payload.get('id')
@@ -87,11 +84,8 @@ def start_task(task_route):
 def update_task():
 
   # Parse request payload
-  try:
-    payload = json.loads(request.data)
-    logger.info(f"[STATUS] Payload: {payload}")
-  except Exception as ex:
-    raise APIUnprocessableEntity('Failed to parse request body as valid JSON') from ex
+  payload = load_json_from_request(request)
+  logger.info(f"[STATUS] Payload: {payload}")
 
   # Marshall JSON to PubSubStatus object
   # Get the task ID from the payload (raises an error if not provided)

--- a/src/modules/site-v2/application.py
+++ b/src/modules/site-v2/application.py
@@ -331,24 +331,6 @@ def register_errorhandlers(app):
   app.register_error_handler(exc.SQLAlchemyError, handle_db_exceptions)
 
 
-# def close_active_connections(err):
-#   # from sqlalchemy.orm import close_all_sessions
-
-#   # # If the request threw an error, roll back the session
-#   # if err is not None:
-#   #   logger.error(f'Teardown Request Exception: {err}')
-#   #   try:
-#   #     db.session.rollback()
-#   #   except Exception as rollback_err:
-#   #     logger.error(f'Exception rolling back session: {rollback_err}')
-
-#   try:
-#     # close_all_sessions()
-#     db.session.remove()
-#   except Exception as db_err:
-#     logger.error(f'Exception closing sessions: {db_err}')
-
-
 def register_request_handlers(app):
 
   # Redirect all URLs that point to this application to the host value in MODULE_SITE_HOST
@@ -358,13 +340,6 @@ def register_request_handlers(app):
   def handle_redirects():
     if request.host != MODULE_SITE_HOST:
       return redirect(request.scheme + "://" + MODULE_SITE_HOST + request.full_path, code=301)
-
-
-  @app.teardown_appcontext
-  def close_db_connections(error):
-    logger.debug('Closing db session...')
-    db.session.close()
-    db.get_engine(app).dispose()
 
 
 def password_protect_site(app):

--- a/src/modules/site-v2/templates/_scripts/fullscreen.js
+++ b/src/modules/site-v2/templates/_scripts/fullscreen.js
@@ -10,19 +10,25 @@ const fullScreenAvailable = document.fullscreenEnabled ||
 /* Run any time fullscreen changes */
 function onFullscreenChange() {
 
+  // Update the fullscreen close button
+  closeButton.style.display = (closeButton.style.display === 'block') ? 'none' : 'block';
+
   // Check for an IGV variable and trigger browser(s) to resize
   if (typeof igv !== 'undefined') igv.visibilityChange();
+
+  // Dispatch a unified event, so individual pages can make specific changes
+  window.dispatchEvent(new CustomEvent('fullscreenchangefinished'))
 }
 
 
 if (fullScreenAvailable) {
   function openFullscreen() {
     if (fullscreenBrowser.requestFullscreen) {
-      fullscreenBrowser.requestFullscreen().then(onFullscreenChange);
+      fullscreenBrowser.requestFullscreen();
     } else if (fullscreenBrowser.webkitRequestFullscreen) { /* Safari */
-      fullscreenBrowser.webkitRequestFullscreen().then(onFullscreenChange);
+      fullscreenBrowser.webkitRequestFullscreen();
     } else if (fullscreenBrowser.msRequestFullscreen) { /* IE11 */
-      fullscreenBrowser.msRequestFullscreen().then(onFullscreenChange);
+      fullscreenBrowser.msRequestFullscreen();
     }
   }
 } else {
@@ -32,42 +38,23 @@ if (fullScreenAvailable) {
 
   function closeFullscreen() {
     if (document.exitFullscreen) {
-      document.exitFullscreen().then(onFullscreenChange);
+      document.exitFullscreen();
     } else if (document.webkitExitFullscreen) { /* Safari */
-      document.webkitExitFullscreen().then(onFullscreenChange);
+      document.webkitExitFullscreen();
     } else if (document.msExitFullscreen) { /* IE11 */
-      document.msExitFullscreen().then(onFullscreenChange);
+      document.msExitFullscreen();
     }
   }
 
-document.addEventListener("fullscreenchange", function() {
-  if (closeButton.style.display === "block") {
-    closeButton.style.display = "none";
-  } else {
-    closeButton.style.display = "block";
-  }
-});
-document.addEventListener("mozfullscreenchange", function() {
-  if (closeButton.style.display === "block") {
-    closeButton.style.display = "none";
-  } else {
-    closeButton.style.display = "block";
-  }
-});
+// Attach the listener to change events so it's triggered when exiting fullscreen w Esc button
+document.addEventListener("fullscreenchange",    onFullscreenChange);
+document.addEventListener("mozfullscreenchange", onFullscreenChange);
+document.addEventListener("msfullscreenchange",  onFullscreenChange);
+
+// Additional behavior for webkit browsers
 document.addEventListener("webkitfullscreenchange", function() {
-  if (closeButton.style.display === "block") {
-    closeButton.style.display = "none";
-  } else {
-    closeButton.style.display = "block";
-  }
+  onFullscreenChange();
   if (window.matchMedia("(min-width: 1370px)").matches) {
-         closeButton.classList.display = "none";
-       }
-});
-document.addEventListener("msfullscreenchange", function() {
-  if (closeButton.style.display === "block") {
-    closeButton.style.display = "none";
-  } else {
-    closeButton.style.display = "block";
+    closeButton.classList.display = "none";
   }
 });

--- a/src/modules/site-v2/templates/tools/heritability_calculator/result.html
+++ b/src/modules/site-v2/templates/tools/heritability_calculator/result.html
@@ -197,6 +197,7 @@
         return color;
     }
 
+    var renderPlot;
     var cpal = []
     var loadPlot = function(jj){
         df = [];
@@ -209,14 +210,26 @@
             for (var cc=0; cc<UniqueNames.length; cc++){cpal.push(getRandomColor())};
         }
 
-        width = document.getElementById("svgchartarea").offsetWidth - 100; /* 100px is from the chart legend*/
-        height = 9 * width / 16;
-        console.log(width)
-        var chart = d3.exploding_boxplot(df, {y:'Value', group:'Strain', color:'AssayNumber', label:'TraitName', pal:cpal})
-                      .width(width)
-                      .height(height);
-        document.getElementById("svgchartarea").innerHTML = "";
-        chart('#svgchartarea');
+        // Create & save a function to compute the chart size & re-render it
+        renderPlot = function() {
+
+          // Clear the current chart area
+          // Otherwise chart can't shrink - width computation will always be based on existing size
+          document.getElementById("svgchartarea").innerHTML = "";
+
+          // Take up as much horizontal space as available, keeping a 16:9 ratio
+          width = document.getElementById("svgchartarea").offsetWidth - 100; /* 100px is from the chart legend*/
+          height = 9 * width / 16;
+
+          // Create the chart and render in the page
+          var chart = d3.exploding_boxplot(df, {y:'Value', group:'Strain', color:'AssayNumber', label:'TraitName', pal:cpal})
+                        .width(width)
+                        .height(height);
+          chart('#svgchartarea');
+        }
+
+        // Call the new render plot function
+        renderPlot();
     }
 
     async function drawImg(canvas, image, DOMURL, w, h){
@@ -340,6 +353,11 @@
       $("a[href^='http://'], a[href^='https://'], a[href$='pdf']").attr("target","_blank");
 
     })
+
+    // When fullscreen changes, recompute plot to update size
+    window.addEventListener('fullscreenchangefinished', () => {
+      renderPlot();
+    });
 
 // For viewing tool in fullscreen
 {% include '_scripts/fullscreen.js' %} {#/* fullscreen for tools */#}

--- a/src/pkg/caendr/caendr/services/heritability_report.py
+++ b/src/pkg/caendr/caendr/services/heritability_report.py
@@ -78,7 +78,7 @@ def fetch_heritability_report(report):
 
   # Parse data file
   data = download_blob_as_dataframe(data)
-  data['AssayNumber'] = data['AssayNumber'].astype(str)
+  data['AssayNumber'] = data['AssayNumber'].astype(int)
   data['label'] = data.apply(lambda x: f"{x['AssayNumber']}: {x['Value']}", 1)
   data = data.to_dict('records')
 

--- a/src/pkg/caendr/caendr/services/sql/db.py
+++ b/src/pkg/caendr/caendr/services/sql/db.py
@@ -11,7 +11,6 @@ from diskcache import Cache
 from caendr.models.error import BadRequestError
 from caendr.models.sql import Homolog, Strain, StrainAnnotatedVariant, WormbaseGene, WormbaseGeneSummary
 from caendr.services.cloud.storage import upload_blob_from_file_as_chunks, generate_blob_url, download_blob_to_file
-from caendr.services.cloud.postgresql import db
 from caendr.utils.file import download_file
 
 cache = Cache("cachedir")


### PR DESCRIPTION
A few minor tweaks, bundled together:

- Update a few API error codes, to be more semantically accurate
- Remove obsolete code to explicitly close db on app context teardown
  - This is handled by Flask SQLAlchemy
  - I originally wrote these functions trying to debug the stale GCP connection issue (see #387 for the actual fix)
- Heritability report:
  - Update graph size on fullscreen
  - Order AssayNumber numerically (1, 2 ... 9, 10 ...) instead of alphabetically (1, 10, 11 ... 2, 3 ...)