### PR TITLE
Displaying file upload strain errors all at once

### DIFF
--- a/src/modules/site-v2/base/utils/tools.py
+++ b/src/modules/site-v2/base/utils/tools.py
@@ -168,7 +168,11 @@ def try_submit(EntityClass, user, data, no_cache):
       msg += f' (Line: { ex.line })'
 
     # Return the error message
-    return { 'message': msg }, 400
+    return {
+      'message': msg,
+      'full_msg_link': ex.full_msg_link,
+      'full_msg_body': ex.full_msg_body,
+    }, 400
 
   # General error
   except Exception as ex:

--- a/src/modules/site-v2/base/views/tools/genetic_mapping.py
+++ b/src/modules/site-v2/base/views/tools/genetic_mapping.py
@@ -116,7 +116,7 @@ def submit():
       response, code = try_submit(NemascanMapping, user, data, no_cache)
 
       # If there was an error, flash it
-      if code != 200 and int(request.args.get('reloadonerr', 1)):
+      if code != 200 and int(request.args.get('reloadonerror', 1)):
         flash(response['message'], 'danger')
 
       # If the response contains a caching message, flash it

--- a/src/modules/site-v2/base/views/tools/genetic_mapping.py
+++ b/src/modules/site-v2/base/views/tools/genetic_mapping.py
@@ -123,10 +123,10 @@ def submit():
     response, code = try_submit(NemascanMapping, user, data, no_cache)
 
     # If there was an error, flash it
-    if not code == 200:
+    if code != 200 and int(request.args.get('reloadonerr', 1)):
       flash(response['message'], 'danger')
 
-    elif response.get('message') and response['ready']:
+    elif response.get('message') and response.get('ready', False):
       flash(response.get('message'), 'success')
 
     # Return the response

--- a/src/modules/site-v2/base/views/tools/heritability_calculator.py
+++ b/src/modules/site-v2/base/views/tools/heritability_calculator.py
@@ -181,10 +181,10 @@ def submit():
     response, code = try_submit(HeritabilityReport, user, data, no_cache)
 
     # If there was an error, flash it
-    if not code == 200:
+    if code != 200 and int(request.args.get('reloadonerr', 1)):
       flash(response['message'], 'danger')
 
-    elif response.get('message') and response['ready']:
+    elif response.get('message') and response.get('ready', False):
       flash(response.get('message'), 'success')
 
     # Return the response

--- a/src/modules/site-v2/base/views/tools/heritability_calculator.py
+++ b/src/modules/site-v2/base/views/tools/heritability_calculator.py
@@ -174,7 +174,7 @@ def submit():
       response, code = try_submit(HeritabilityReport, user, data, no_cache)
 
       # If there was an error, flash it
-      if code != 200 and int(request.args.get('reloadonerr', 1)):
+      if code != 200 and int(request.args.get('reloadonerror', 1)):
         flash(response['message'], 'danger')
 
       # If the response contains a caching message, flash it

--- a/src/modules/site-v2/base/views/tools/pairwise_indel_finder.py
+++ b/src/modules/site-v2/base/views/tools/pairwise_indel_finder.py
@@ -243,7 +243,7 @@ def submit():
   response, code = try_submit(IndelPrimer, user, data, no_cache)
 
   # If there was an error, flash it
-  if code != 200 and int(request.args.get('reloadonerr', 1)):
+  if code != 200 and int(request.args.get('reloadonerror', 1)):
     flash(response['message'], 'danger')
 
   # Return the response

--- a/src/modules/site-v2/base/views/tools/pairwise_indel_finder.py
+++ b/src/modules/site-v2/base/views/tools/pairwise_indel_finder.py
@@ -243,7 +243,7 @@ def submit():
   response, code = try_submit(IndelPrimer, user, data, no_cache)
 
   # If there was an error, flash it
-  if not code == 200:
+  if code != 200 and int(request.args.get('reloadonerr', 1)):
     flash(response['message'], 'danger')
 
   # Return the response

--- a/src/modules/site-v2/templates/_includes/alert.html
+++ b/src/modules/site-v2/templates/_includes/alert.html
@@ -1,0 +1,4 @@
+<div class="container alert alert-{{ category }} alert-dismissible fade show pt-3 my-5 fw-bold text-center">
+    <p>{{ msg }}</p>
+    <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+</div>

--- a/src/modules/site-v2/templates/_includes/snackbar.html
+++ b/src/modules/site-v2/templates/_includes/snackbar.html
@@ -1,6 +1,5 @@
+<div id="alert-container">
 {% for category, msg in get_flashed_messages(with_categories=true) %}
-    <div class="container alert alert-{{ category }} alert-dismissible fade show pt-3 my-5 fw-bold text-center">
-        <p>{{ msg }}</p>
-        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
-    </div>
+    {% include '_includes/alert.html' %}
 {% endfor %}
+</div>

--- a/src/modules/site-v2/templates/_scripts/submit-job.js
+++ b/src/modules/site-v2/templates/_scripts/submit-job.js
@@ -18,7 +18,24 @@ $.ajaxSetup({
   If defining with `as_form_data` = True, must include `ajax_setup` on the page (defined above).
 #}
 {% macro def_submit_job(tool_name, as_form_data=false, func_name='submit_job') %}
-function {{func_name}}(data, modal_id, new_tab=false) {
+function {{func_name}}(data, modal_id, new_tab=false, propagate_err=true) {
+
+  // Gather URL variable(s)
+  let url_vars = [];
+  if (propagate_err) {
+    url_vars.push('reloadonerr=0');
+  }
+  {%- if session["is_admin"] %}
+  if ($('#no_cache_checkbox').prop('checked')) {
+    url_vars.push('nocache=1');
+  }
+  {%- endif %}
+
+  // Create full URL, appending URL vars if any were created
+  let url = "{{ url_for(tool_name + '.submit') }}";
+  if (url_vars.length) {
+    url += '?' + url_vars.join('&');
+  }
 
   return $.ajax({
     type: "POST",
@@ -26,12 +43,7 @@ function {{func_name}}(data, modal_id, new_tab=false) {
     contentType: {% if as_form_data -%} false {%- else -%} "application/json; charset=utf-8" {%- endif -%},
     dataType: 'json',
     data: {% if as_form_data -%} data {%- else -%} JSON.stringify(data) {%- endif -%},
-    url:
-      {%- if session["is_admin"] %}
-        "{{ url_for(tool_name + '.submit') }}" + ($('#no_cache_checkbox').prop('checked') ? "?nocache=1" : ""),
-      {%- else %}
-        "{{ url_for(tool_name + '.submit') }}",
-      {%- endif %}
+    url: url,
   })
     .done((result) => {
       // TODO: Display message based on cache status?
@@ -57,7 +69,7 @@ function {{func_name}}(data, modal_id, new_tab=false) {
       if (error.responseJSON) {
         const message = error.responseJSON.message;
         if (message) {
-          window.location.reload();
+          if (!propagate_err) window.location.reload();
         } else {
           console.error(error);
         }

--- a/src/modules/site-v2/templates/_scripts/submit-job.js
+++ b/src/modules/site-v2/templates/_scripts/submit-job.js
@@ -18,7 +18,11 @@ $.ajaxSetup({
   If defining with `as_form_data` = True, must include `ajax_setup` on the page (defined above).
 #}
 {% macro def_submit_job(tool_name, as_form_data=false, func_name='submit_job') %}
-function {{func_name}}(data, modal_id, new_tab=false, propagate_error=true) {
+function {{func_name}}(data, modal_id, config={}) {
+
+  // Extract configuration settings w default values
+  const new_tab         = config.hasOwnProperty('new_tab')         ? config['new_tab']         : false;
+  const propagate_error = config.hasOwnProperty('propagate_error') ? config['propagate_error'] : true;
 
   // Gather URL variable(s)
   let url_vars = [];

--- a/src/modules/site-v2/templates/_scripts/submit-job.js
+++ b/src/modules/site-v2/templates/_scripts/submit-job.js
@@ -18,12 +18,12 @@ $.ajaxSetup({
   If defining with `as_form_data` = True, must include `ajax_setup` on the page (defined above).
 #}
 {% macro def_submit_job(tool_name, as_form_data=false, func_name='submit_job') %}
-function {{func_name}}(data, modal_id, new_tab=false, propagate_err=true) {
+function {{func_name}}(data, modal_id, new_tab=false, propagate_error=true) {
 
   // Gather URL variable(s)
   let url_vars = [];
-  if (propagate_err) {
-    url_vars.push('reloadonerr=0');
+  if (propagate_error) {
+    url_vars.push('reloadonerror=0');
   }
   {%- if session["is_admin"] %}
   if ($('#no_cache_checkbox').prop('checked')) {
@@ -69,7 +69,7 @@ function {{func_name}}(data, modal_id, new_tab=false, propagate_err=true) {
       if (error.responseJSON) {
         const message = error.responseJSON.message;
         if (message) {
-          if (!propagate_err) window.location.reload();
+          if (!propagate_error) window.location.reload();
         } else {
           console.error(error);
         }

--- a/src/modules/site-v2/templates/_scripts/utils.js
+++ b/src/modules/site-v2/templates/_scripts/utils.js
@@ -143,4 +143,9 @@ function flash_message(message, full_msg_link=null, full_msg_body=null) {
 
   // Add the new node to the container for alert messages
   document.getElementById('alert-container').appendChild(node);
+
+  // Italicize species name(s) in the alert message
+  {%- for species in species_list.values() %}
+  node.innerHTML = node.innerHTML.replace('{{ species.short_name }}', '<i>{{ species.short_name }}</i>')
+  {%- endfor %}
 }

--- a/src/modules/site-v2/templates/_scripts/utils.js
+++ b/src/modules/site-v2/templates/_scripts/utils.js
@@ -128,7 +128,7 @@ function flash_message(message, full_msg_link=null, full_msg_body=null) {
     node.firstElementChild.innerText += ' ';
 
     // Create a unique ID to link the trigger & collapse elements
-    const id = `err-dropdown-${(new Date()).getTime()}`;
+    const id = `error-dropdown-${(new Date()).getTime()}`;
 
     // Create a link to open the full message
     const full_msg_link_el = create_node(`<a data-bs-toggle="collapse" href="#${id}" role="button" aria-expanded="false" aria-controls="${id}"></a>`);

--- a/src/modules/site-v2/templates/_scripts/utils.js
+++ b/src/modules/site-v2/templates/_scripts/utils.js
@@ -111,7 +111,7 @@ function create_node(html) {
 /* Flash a message to the user without reloading the page.
  * This function is roundabout to prevent code injection.
  */
-function flash_message(message) {
+function flash_message(message, full_msg_link=null, full_msg_body=null) {
 
   // Define the template for an alert popup using a static string
   {%- with msg='', category='danger' %}
@@ -122,6 +122,24 @@ function flash_message(message) {
   // Inserting as text protects against code injection
   const node = create_node(raw_html);
   node.firstElementChild.innerText = message;
+
+  // If both full message fields are provided, add as a link & collapse dropdown
+  if (full_msg_link && full_msg_body) {
+    node.firstElementChild.innerText += ' ';
+
+    // Create a unique ID to link the trigger & collapse elements
+    const id = `err-dropdown-${(new Date()).getTime()}`;
+
+    // Create a link to open the full message
+    const full_msg_link_el = create_node(`<a data-bs-toggle="collapse" href="#${id}" role="button" aria-expanded="false" aria-controls="${id}"></a>`);
+    full_msg_link_el.innerText = full_msg_link;
+    node.firstElementChild.appendChild(full_msg_link_el);
+
+    // Create a collapse element containing the full message
+    const full_msg_body_el = create_node(`<div class="collapse" id="${id}"></div>`);
+    full_msg_body_el.innerText = full_msg_body;
+    node.appendChild(full_msg_body_el);
+  }
 
   // Add the new node to the container for alert messages
   document.getElementById('alert-container').appendChild(node);

--- a/src/modules/site-v2/templates/_scripts/utils.js
+++ b/src/modules/site-v2/templates/_scripts/utils.js
@@ -98,3 +98,31 @@ function force_download(e) {
       a.click();
     })
 }
+
+
+/* Create a DOM node from a string of HTML, without adding the element to the DOM yet */
+function create_node(html) {
+  const placeholder = document.createElement("div");
+  placeholder.innerHTML = html;
+  return placeholder.firstElementChild;
+}
+
+
+/* Flash a message to the user without reloading the page.
+ * This function is roundabout to prevent code injection.
+ */
+function flash_message(message) {
+
+  // Define the template for an alert popup using a static string
+  {%- with msg='', category='danger' %}
+  const raw_html = `{% include '_includes/alert.html' %}`;
+  {%- endwith %}
+
+  // Create as a new DOM node, and insert the desired message as text
+  // Inserting as text protects against code injection
+  const node = create_node(raw_html);
+  node.firstElementChild.innerText = message;
+
+  // Add the new node to the container for alert messages
+  document.getElementById('alert-container').appendChild(node);
+}

--- a/src/modules/site-v2/templates/tools/genetic_mapping/mapping.html
+++ b/src/modules/site-v2/templates/tools/genetic_mapping/mapping.html
@@ -173,8 +173,9 @@ $("#form-submit").on("submit", function(e) {
     })
     // If file validation fails: flash the error, reset the file input, and re-enable the submit button
     .fail((error) => {
-      if (error.responseJSON && error.responseJSON.message) {
-        flash_message(error.responseJSON.message);
+      const resp = error.responseJSON
+      if (resp && resp.message) {
+        flash_message(resp.message, resp.full_msg_link, resp.full_msg_body);
       }
       document.getElementById('{{ form.file.id }}').value = '';
       enableButton();

--- a/src/modules/site-v2/templates/tools/genetic_mapping/mapping.html
+++ b/src/modules/site-v2/templates/tools/genetic_mapping/mapping.html
@@ -133,6 +133,7 @@
 {% from "_scripts/submit-job.js" import def_submit_job %}
 {% from "_includes/macros.html" import update_species_field %}
 <script>
+{% include '_scripts/utils.js' %} {#/* defines: flash_message */#}
 
 {{ def_submit_job('genetic_mapping', true) }}
 
@@ -166,9 +167,17 @@ $("#form-submit").on("submit", function(e) {
   const data = new FormData($('form#form-submit')[0]);
 
   submit_job(data, '#submitModal')
+    // Reset the form after a successful (non-error) submission
     .done((result) => {
-      // Reset the form after a successful (non-error) submission
       resetForm();
+    })
+    // If file validation fails: flash the error, reset the file input, and re-enable the submit button
+    .fail((error) => {
+      if (error.responseJSON && error.responseJSON.message) {
+        flash_message(error.responseJSON.message);
+      }
+      document.getElementById('{{ form.file.id }}').value = '';
+      enableButton();
     })
 });
 

--- a/src/modules/site-v2/templates/tools/heritability_calculator/heritability-calculator.html
+++ b/src/modules/site-v2/templates/tools/heritability_calculator/heritability-calculator.html
@@ -131,6 +131,7 @@
 {% from "_scripts/submit-job.js" import def_submit_job %}
 {% from "_includes/macros.html" import update_species_field %}
 <script>
+{% include '_scripts/utils.js' %} {#/* defines: flash_message */#}
 
 {{ def_submit_job('heritability_calculator', true) }}
 
@@ -164,9 +165,17 @@ $("#form-submit").on("submit", function(e) {
   const data = new FormData($('form#form-submit')[0]);
 
   submit_job(data, '#submit-modal')
+    // Reset the form after a successful (non-error) submission
     .done((result) => {
-      // Reset the form after a successful (non-error) submission
       resetForm();
+    })
+    // If file validation fails: flash the error, reset the file input, and re-enable the submit button
+    .fail((error) => {
+      if (error.responseJSON && error.responseJSON.message) {
+        flash_message(error.responseJSON.message);
+      }
+      document.getElementById('{{ form.file.id }}').value = '';
+      enableButton();
     })
 });
 

--- a/src/modules/site-v2/templates/tools/heritability_calculator/heritability-calculator.html
+++ b/src/modules/site-v2/templates/tools/heritability_calculator/heritability-calculator.html
@@ -171,8 +171,9 @@ $("#form-submit").on("submit", function(e) {
     })
     // If file validation fails: flash the error, reset the file input, and re-enable the submit button
     .fail((error) => {
-      if (error.responseJSON && error.responseJSON.message) {
-        flash_message(error.responseJSON.message);
+      const resp = error.responseJSON
+      if (resp && resp.message) {
+        flash_message(resp.message, resp.full_msg_link, resp.full_msg_body);
       }
       document.getElementById('{{ form.file.id }}').value = '';
       enableButton();

--- a/src/modules/site-v2/templates/tools/pairwise_indel_finder/submit.html
+++ b/src/modules/site-v2/templates/tools/pairwise_indel_finder/submit.html
@@ -549,7 +549,7 @@ function generate_primers(e) {
   }
 
   // Submit the job, opening results in a new tab if applicable
-  submit_job(data, '#generate-primers-modal', true)
+  submit_job(data, '#generate-primers-modal', true, false)
     .done(() => {
       $(this).text("Submitted");
       $(this).prop('onclick', null).off('click');

--- a/src/modules/site-v2/templates/tools/pairwise_indel_finder/submit.html
+++ b/src/modules/site-v2/templates/tools/pairwise_indel_finder/submit.html
@@ -549,7 +549,7 @@ function generate_primers(e) {
   }
 
   // Submit the job, opening results in a new tab if applicable
-  submit_job(data, '#generate-primers-modal', true, false)
+  submit_job(data, '#generate-primers-modal', {'new_tab': true, 'propagate_error': false})
     .done(() => {
       $(this).text("Submitted");
       $(this).prop('onclick', null).off('click');

--- a/src/pkg/caendr/caendr/models/error.py
+++ b/src/pkg/caendr/caendr/models/error.py
@@ -137,9 +137,11 @@ class DuplicateTaskError(InternalError):
 
 class DataFormatError(InternalError):
   description = "Error parsing data with expected format"
-  def __init__(self, msg, line: int=None):
+  def __init__(self, msg, line: int=None, full_msg_body: str=None, full_msg_link: str=None):
     self.msg  = msg.strip()
     self.line = line
+    self.full_msg_body = full_msg_body
+    self.full_msg_link = full_msg_link
     super().__init__()
 
 class GoogleSheetsParseError(InternalError):

--- a/src/pkg/caendr/caendr/services/tools/submit.py
+++ b/src/pkg/caendr/caendr/services/tools/submit.py
@@ -553,60 +553,54 @@ def validate_strain(species, force_unique=False, force_unique_msg=None):
     'unknown_strain': [],
   }
 
+
+  def check_strain_list(problem_list, err_messages):
+    truncate_length = 3
+
+    prob_strains = []
+    for s in problem_list:
+      if s['value'] not in prob_strains:
+        prob_strains.append(s['value'])
+    num_problems = len(prob_strains)
+
+    if num_problems == 1:
+      raise DataFormatError( err_messages['single'](prob_strains[0]) )
+
+    elif 1 < num_problems <= truncate_length:
+      prob_str = join_commas_and(prob_strains)
+      raise DataFormatError( err_messages['few'](prob_str) )
+
+    elif num_problems > truncate_length:
+      prob_str = join_commas_and(prob_strains, truncate=truncate_length)
+      raise DataFormatError(
+        err_messages['many'](prob_str),
+        full_msg_link='View the full list of strains.',
+        full_msg_body=', '.join(prob_strains),
+      )
+
+
   # Validator function run at the end of the file
   def func_final():
     nonlocal problems
-    truncate_length = 4
-
 
     # Wrong species #
-
-    prob_strains = []
-    for s in problems['wrong_species']:
-      if s['value'] not in prob_strains:
-        prob_strains.append(s['value'])
-
-    num_problems = len(prob_strains)
-    if num_problems == 1:
-      raise DataFormatError(f'The strain { prob_strains[0] } is not a valid strain for { species.short_name } in our current dataset. Please enter a valid { species.short_name } strain.')
-    elif 1 < num_problems <= truncate_length:
-      prob_str = join_commas_and(prob_strains)
-      raise DataFormatError(f'The strains { prob_str } are not valid strains for { species.short_name } in our current dataset. Please enter valid { species.short_name } strains.')
-    elif num_problems > truncate_length:
-      raise DataFormatError(
-        f'Multiple strains are not valid for { species.short_name } in our current dataset.',
-        full_msg_link='View the full list of strains.',
-        full_msg_body=', '.join(prob_strains),
-      )
-
+    check_strain_list(problems['wrong_species'], {
+      'single': lambda x: f'The strain { x } is not a valid strain for { species.short_name } in our current dataset. Please enter a valid { species.short_name } strain.',
+      'few':    lambda x: f'The strains { x } are not valid strains for { species.short_name } in our current dataset. Please enter valid { species.short_name } strains.',
+      'many':   lambda x: f'Multiple strains are not valid for { species.short_name } in our current dataset.',
+    })
 
     # Blank lines #
-
-    num_problems = len(problems['blank_line'])
-    if num_problems > 0:
+    if len(problems['blank_line']) > 0:
       line_str = join_commas_and([ p['line'] for p in problems['blank_line'] ])
       raise DataFormatError(f'Strain values cannot be blank. Please check line(s) { line_str } to ensure valid strains have been entered.')
 
-
     # Unknown strains #
-
-    prob_strains = []
-    for s in problems['unknown_strain']:
-      if s['value'] not in prob_strains:
-        prob_strains.append(s['value'])
-
-    num_problems = len(prob_strains)
-    if num_problems == 1:
-      raise DataFormatError(f'The strain { prob_strains[0] } is not a valid strain name in our current dataset. Please enter valid strain names.')
-    elif 1 < num_problems <= truncate_length:
-      prob_str = join_commas_and(prob_strains)
-      raise DataFormatError(f'The strains { prob_str } are not valid strain names in our current dataset. Please enter valid strain names.')
-    elif num_problems > truncate_length:
-      raise DataFormatError(
-        f'Multiple strains are not valid in our current dataset.',
-        full_msg_link='View the full list of strains.',
-        full_msg_body=', '.join(prob_strains),
-      )
+    check_strain_list(problems['unknown_strain'], {
+      'single': lambda x: f'The strain { x } is not a valid strain name in our current dataset. Please enter valid strain names.',
+      'few':    lambda x: f'The strains { x } are not valid strain names in our current dataset. Please enter valid strain names.',
+      'many':   lambda x: f'Multiple strains are not valid in our current dataset.',
+    })
 
 
   # Validator function run on each individual line

--- a/src/pkg/caendr/caendr/services/tools/submit.py
+++ b/src/pkg/caendr/caendr/services/tools/submit.py
@@ -556,6 +556,7 @@ def validate_strain(species, force_unique=False, force_unique_msg=None):
   # Validator function run at the end of the file
   def func_final():
     nonlocal problems
+    truncate_length = 4
 
 
     # Blank lines #
@@ -576,9 +577,15 @@ def validate_strain(species, force_unique=False, force_unique_msg=None):
     num_problems = len(prob_strains)
     if num_problems == 1:
       raise DataFormatError(f'The strain { prob_strains[0] } is not a valid strain for { species.short_name } in our current dataset. Please enter a valid { species.short_name } strain.')
-    elif num_problems > 1:
-      prob_str = join_commas_and(prob_strains, truncate=8)
+    elif 1 < num_problems <= truncate_length:
+      prob_str = join_commas_and(prob_strains)
       raise DataFormatError(f'The strains { prob_str } are not valid strains for { species.short_name } in our current dataset. Please enter valid { species.short_name } strains.')
+    elif num_problems > truncate_length:
+      raise DataFormatError(
+        f'Multiple strains are not valid for { species.short_name } in our current dataset.',
+        full_msg_link='View the full list of strains.',
+        full_msg_body=', '.join(prob_strains),
+      )
 
 
     # Unknown strains #
@@ -591,9 +598,15 @@ def validate_strain(species, force_unique=False, force_unique_msg=None):
     num_problems = len(prob_strains)
     if num_problems == 1:
       raise DataFormatError(f'The strain { prob_strains[0] } is not a valid strain name in our current dataset. Please enter valid strain names.')
-    elif num_problems > 1:
-      prob_str = join_commas_and(prob_strains, truncate=8)
+    elif 1 < num_problems <= truncate_length:
+      prob_str = join_commas_and(prob_strains)
       raise DataFormatError(f'The strains { prob_str } are not valid strain names in our current dataset. Please enter valid strain names.')
+    elif num_problems > truncate_length:
+      raise DataFormatError(
+        f'Multiple strains are not valid in our current dataset.',
+        full_msg_link='View the full list of strains.',
+        full_msg_body=', '.join(prob_strains),
+      )
 
 
   # Validator function run on each individual line

--- a/src/pkg/caendr/caendr/services/tools/submit.py
+++ b/src/pkg/caendr/caendr/services/tools/submit.py
@@ -559,14 +559,6 @@ def validate_strain(species, force_unique=False, force_unique_msg=None):
     truncate_length = 4
 
 
-    # Blank lines #
-
-    num_problems = len(problems['blank_line'])
-    if num_problems > 0:
-      line_str = join_commas_and([ p['line'] for p in problems['blank_line'] ])
-      raise DataFormatError(f'Strain values cannot be blank. Please check line(s) { line_str } to ensure valid strains have been entered.')
-
-
     # Wrong species #
 
     prob_strains = []
@@ -586,6 +578,14 @@ def validate_strain(species, force_unique=False, force_unique_msg=None):
         full_msg_link='View the full list of strains.',
         full_msg_body=', '.join(prob_strains),
       )
+
+
+    # Blank lines #
+
+    num_problems = len(problems['blank_line'])
+    if num_problems > 0:
+      line_str = join_commas_and([ p['line'] for p in problems['blank_line'] ])
+      raise DataFormatError(f'Strain values cannot be blank. Please check line(s) { line_str } to ensure valid strains have been entered.')
 
 
     # Unknown strains #

--- a/src/pkg/caendr/caendr/utils/data.py
+++ b/src/pkg/caendr/caendr/utils/data.py
@@ -111,3 +111,42 @@ def get_file_format(file_ext, valid_formats=None):
 
   # If none matched, return None
   return None
+
+
+
+
+def join_with_final(text, sep='', final=None, final_if_two=None):
+  '''
+    Like string join, but with finer control. See arguments for details.
+
+    Arguments:
+      text (list): list of strings to be joined
+      sep (str): The default separator between elements.
+      final (str): The separator between the penultimate and final elements.
+      final_if_two (str): A special separator to use if there are exactly two elements.
+  '''
+  if len(text) == 2 and final_if_two is not None:
+    return final_if_two.join(text)
+  if final:
+    return final.join([ x for x in [sep.join(text[:-1]), *text[-1:]] if x ])
+  return sep.join(text)
+
+
+def join_commas_and(text, truncate=None):
+  '''
+    Join a list like written English, using commas and "and".
+    Supports list truncation, e.g. "x, y, z, and 3 more"
+
+    Cases:
+      - If there is one element, returns that element as-is
+      - If there are 2 elements, returns "x and y"
+      - If there are 3+ elements, returns e.g. "x, y, and z"
+
+    Arguments:
+      text (list): List of strings to be joined
+      truncate (int, optional): The maximum number of elements to spell out in the list.
+          If there are more elements, these are replaced with "and n more"
+  '''
+  if truncate:
+    text = text[:truncate] + ([f'{len(text) - truncate} more'] if len(text) > truncate else [])
+  return join_with_final(text, sep=', ', final=', and ', final_if_two=' and ')


### PR DESCRIPTION
- Validators are now split into two functions: the `step` and the `final`
  - For `validate_strains`, the `step` keeps a list of invalid lines, categorized by error type: wrong species, unknown strain, blank strain, and (optionally) duplicate strain
  - For `validate_strains`, the `final` runs through each category, and displays the first one that has one or more errors
  - For the other validators, only the `step` is required (remains unchanged)
- Error messages are meant to be human-readable
  - If 1-3 strains are invalid, display those in an inline list (using correct pluralization, commas + "and", etc)
  - If 4+ are invalid, include a dropdown (a BS `collapse` element) with the full list
  - Species names are italicized
- Submission API calls accept an optional URL variable `reloadonerr`
  - If `0`, returns the error message without using Flask `flash`. The JS function will manually show the error without reloading the page
  - If `1` or unset, uses `flash` to display the message. The JS function will reload the page to make this appear