### PR TITLE
Make file column validators into classes

### DIFF
--- a/src/pkg/caendr/caendr/models/job_pipeline/heritability_pipeline.py
+++ b/src/pkg/caendr/caendr/models/job_pipeline/heritability_pipeline.py
@@ -9,8 +9,9 @@ from caendr.models.run             import HeritabilityRunner
 # Services
 from caendr.models.datastore       import Species
 from caendr.models.error           import DataFormatError
-from caendr.services.validate      import get_delimiter_from_filepath, validate_file, NumberValidator, StrainValidator, TraitValidator
+from caendr.services.validate      import validate_file, NumberValidator, StrainValidator, TraitValidator
 from caendr.services.cloud.storage import upload_blob_from_file
+from caendr.utils.data             import get_delimiter_from_filepath
 from caendr.utils.env              import get_env_var
 from caendr.utils.file             import get_file_hash
 

--- a/src/pkg/caendr/caendr/models/job_pipeline/heritability_pipeline.py
+++ b/src/pkg/caendr/caendr/models/job_pipeline/heritability_pipeline.py
@@ -9,7 +9,7 @@ from caendr.models.run             import HeritabilityRunner
 # Services
 from caendr.models.datastore       import Species
 from caendr.models.error           import DataFormatError
-from caendr.services.validate      import get_delimiter_from_filepath, validate_file, NumValidator, StrainValidator, TraitValidator
+from caendr.services.validate      import get_delimiter_from_filepath, validate_file, NumberValidator, StrainValidator, TraitValidator
 from caendr.services.cloud.storage import upload_blob_from_file
 from caendr.utils.env              import get_env_var
 from caendr.utils.file             import get_file_hash
@@ -33,16 +33,16 @@ class HeritabilityPipeline(JobPipeline):
   #
 
   @classmethod
-  def validator_columns(cls, data):
+  def column_validators(cls, data):
     '''
-      Define an expected header & a validator function for each column in the file
+      Create a ColumnValidator object for each column in the file
     '''
     return [
-      { 'header': 'AssayNumber', 'validator': NumValidator()                                        },
-      { 'header': 'Strain',      'validator': StrainValidator( Species.from_name(data['species']) ) },
-      { 'header': 'TraitName',   'validator': TraitValidator()                                      },
-      { 'header': 'Replicate',   'validator': NumValidator()                                        },
-      { 'header': 'Value',       'validator': NumValidator(accept_float=True)                       },
+      NumberValidator( 'AssayNumber' ),
+      StrainValidator( 'Strain', species=Species.from_name(data['species']) ),
+      TraitValidator(  'TraitName' ),
+      NumberValidator( 'Replicate' ),
+      NumberValidator( 'Value', accept_float=True ),
     ]
 
 
@@ -60,7 +60,7 @@ class HeritabilityPipeline(JobPipeline):
 
     # Validate each line in the file
     # Will raise an error if any problems are found, otherwise silently passes
-    validate_file(local_path, cls.validator_columns(data), delimiter=delimiter, unique_rows=True)
+    validate_file(local_path, cls.column_validators(data), delimiter=delimiter, unique_rows=True)
 
     # Extra validation - check that five or more unique strains are provided
     unique_strains = set()

--- a/src/pkg/caendr/caendr/models/job_pipeline/heritability_pipeline.py
+++ b/src/pkg/caendr/caendr/models/job_pipeline/heritability_pipeline.py
@@ -9,7 +9,7 @@ from caendr.models.run             import HeritabilityRunner
 # Services
 from caendr.models.datastore       import Species
 from caendr.models.error           import DataFormatError
-from caendr.services.validate      import get_delimiter_from_filepath, validate_file, validate_num, validate_strain, validate_trait
+from caendr.services.validate      import get_delimiter_from_filepath, validate_file, NumValidator, StrainValidator, TraitValidator
 from caendr.services.cloud.storage import upload_blob_from_file
 from caendr.utils.env              import get_env_var
 from caendr.utils.file             import get_file_hash
@@ -38,11 +38,11 @@ class HeritabilityPipeline(JobPipeline):
       Define an expected header & a validator function for each column in the file
     '''
     return [
-      { 'header': 'AssayNumber', 'validator': validate_num()                                        },
-      { 'header': 'Strain',      'validator': validate_strain( Species.from_name(data['species']) ) },
-      { 'header': 'TraitName',   'validator': validate_trait()                                      },
-      { 'header': 'Replicate',   'validator': validate_num()                                        },
-      { 'header': 'Value',       'validator': validate_num(accept_float=True)                       },
+      { 'header': 'AssayNumber', 'validator': NumValidator()                                        },
+      { 'header': 'Strain',      'validator': StrainValidator( Species.from_name(data['species']) ) },
+      { 'header': 'TraitName',   'validator': TraitValidator()                                      },
+      { 'header': 'Replicate',   'validator': NumValidator()                                        },
+      { 'header': 'Value',       'validator': NumValidator(accept_float=True)                       },
     ]
 
 

--- a/src/pkg/caendr/caendr/models/job_pipeline/nemascan_pipeline.py
+++ b/src/pkg/caendr/caendr/models/job_pipeline/nemascan_pipeline.py
@@ -8,8 +8,9 @@ from caendr.models.run             import NemascanRunner
 
 # Services
 from caendr.models.datastore       import Species
-from caendr.services.validate      import get_delimiter_from_filepath, validate_file, NumberValidator, StrainValidator
+from caendr.services.validate      import validate_file, NumberValidator, StrainValidator
 from caendr.services.cloud.storage import upload_blob_from_file
+from caendr.utils.data             import get_delimiter_from_filepath
 from caendr.utils.env              import get_env_var
 from caendr.utils.file             import get_file_hash
 

--- a/src/pkg/caendr/caendr/models/job_pipeline/nemascan_pipeline.py
+++ b/src/pkg/caendr/caendr/models/job_pipeline/nemascan_pipeline.py
@@ -8,7 +8,7 @@ from caendr.models.run             import NemascanRunner
 
 # Services
 from caendr.models.datastore       import Species
-from caendr.services.validate      import get_delimiter_from_filepath, validate_file, validate_num, validate_strain
+from caendr.services.validate      import get_delimiter_from_filepath, validate_file, NumValidator, StrainValidator
 from caendr.services.cloud.storage import upload_blob_from_file
 from caendr.utils.env              import get_env_var
 from caendr.utils.file             import get_file_hash
@@ -47,11 +47,11 @@ class NemascanPipeline(JobPipeline):
     return [
       {
         'header': 'strain',
-        'validator': validate_strain(Species.from_name(data['species']), force_unique=True, force_unique_msgs=force_unique_msgs)
+        'validator': StrainValidator(Species.from_name(data['species']), force_unique=True, force_unique_msgs=force_unique_msgs)
       },
       {
         # 'header': { 'validator': lambda x: x },
-        'validator': validate_num(accept_float=True, accept_na=True),
+        'validator': NumValidator(accept_float=True, accept_na=True),
       },
     ]
 

--- a/src/pkg/caendr/caendr/services/validate.py
+++ b/src/pkg/caendr/caendr/services/validate.py
@@ -2,28 +2,10 @@ from abc import ABC, abstractmethod
 import csv
 from typing import Callable, Optional, Union
 
-from caendr.services.logger import logger
-
 from caendr.models.error import DataFormatError
 from caendr.api.strain   import query_strains
 from caendr.api.isotype  import get_distinct_isotypes
-from caendr.utils.data   import get_file_format, join_commas_and
-from caendr.utils.env    import get_env_var
-
-
-
-INDEL_PRIMER_CONTAINER_NAME = get_env_var('INDEL_PRIMER_CONTAINER_NAME')
-HERITABILITY_CONTAINER_NAME = get_env_var('HERITABILITY_CONTAINER_NAME')
-NEMASCAN_NXF_CONTAINER_NAME = get_env_var('NEMASCAN_NXF_CONTAINER_NAME')
-
-
-
-def get_delimiter_from_filepath(filepath=None, valid_file_extensions=None):
-  valid_file_extensions = valid_file_extensions or {'csv'}
-  if filepath:
-    file_format = get_file_format(filepath[-3:], valid_formats=valid_file_extensions)
-    if file_format:
-      return file_format['sep']
+from caendr.utils.data   import join_commas_and
 
 
 

--- a/src/pkg/caendr/caendr/services/validate.py
+++ b/src/pkg/caendr/caendr/services/validate.py
@@ -1,3 +1,4 @@
+from abc import ABC, abstractmethod
 import csv
 
 from caendr.services.logger import logger
@@ -91,10 +92,7 @@ def validate_file(local_path, columns, delimiter='\t', unique_rows=False):
 
       # Check that all columns have valid data, using the "step" validator
       for column, value in zip(columns, csv_row):
-        header    = column.get('header')
-        validator = column['validator']
-        if 'step' in validator:
-          validator['step']( header, value.strip(), line )
+        column['validator'].read_line( column.get('header'), value.strip(), line )
 
       # Track that we parsed at least one line of data properly
       has_data = True
@@ -104,74 +102,121 @@ def validate_file(local_path, columns, delimiter='\t', unique_rows=False):
       raise DataFormatError('The file is empty. Please edit the file to include your data.')
 
     # Run each validator's "final" function at the end, in case any of the "step" validators were accumulating values
-    for c in columns:
-      if 'final' in c['validator']:
-        c['validator']['final']()
+    for column in columns:
+      column['validator'].finish()
+
 
 
 
 #
-# Validator Functions
+# Validator Base Class
 #
 
-def validate_num(accept_float = False, accept_na = False):
+class ColumnValidator(ABC):
 
-  # Construct a message for the expected data type
-  if accept_float:
-    data_type = 'decimal'
-  else:
-    data_type = 'integer'
+  @abstractmethod
+  def read_line(self, header, value, line):
+    '''
+      Parse and validate a single line.
+      Can raise errors here, or record them to raise all at once in `finish()`.
 
-  # Define the validator function
-  def func(header, value, line):
-    nonlocal data_type
+      Arguments:
+        header: The column header.
+        value:  The value in the current line, to be validated.
+        line:   The index of the current line.
+    '''
+    pass
+
+  def finish(self):
+    '''
+      Called at the end of the file.
+    '''
+    pass
+
+
+
+#
+# Numeric Values
+#
+
+class NumValidator(ColumnValidator):
+  '''
+    Validator for numeric values.
+  '''
+
+  def __init__(self, accept_float = False, accept_na = False):
+    self.accept_float = accept_float
+    self.accept_na    = accept_na
+
+  @property
+  def data_type(self):
+    '''
+      Construct a message for the expected data type
+    '''
+    return 'decimal' if self.accept_float else 'integer'
+
+  def read_line(self, header, value, line):
 
     # Try casting the value to the appropriate num type
     try:
-      if accept_float:
+      if self.accept_float:
         float(value)
       else:
         int(value)
 
     # If casting fails, raise an error (with an exception for 'NA', if applicable)
     except:
-      if not (accept_na and value == 'NA'):
-        raise DataFormatError(f'Column { header } is not a valid { data_type }. Please edit { header } to ensure only { data_type } values are included.', line)
-
-  return { 'step': func }
+      if not (self.accept_na and value == 'NA'):
+        raise DataFormatError(f'Column { header } is not a valid { self.data_type }. Please edit { header } to ensure only { self.data_type } values are included.', line)
 
 
 
-# Check that column is a valid strain name for the desired species
-def validate_strain(species, force_unique=False, force_unique_msgs=None):
+#
+# Strains
+#
 
-  # Get the list of all valid strain names for this species
-  # Pull from strain names & isotype names, to allow for isotypes with no strain of the same name
-  valid_names_species = {
-    *query_strains(all_strain_names=True, species=species.name),
-    *get_distinct_isotypes(species=species.name),
-  }
+class StrainValidator(ColumnValidator):
+  '''
+    Check that column is a valid strain name for the desired species.
+  '''
 
-  # Get the list of all valid strain names for all species
-  # Used to provide more informative error messages
-  valid_names_all = {
-    *query_strains(all_strain_names=True),
-    *get_distinct_isotypes(),
-  }
+  def __init__(self, species, force_unique=False, force_unique_msgs=None):
 
-  # Dict to track the first line each strain occurs on
-  # Used to ensure strains are unique, if applicable
-  strain_line_numbers = {}
+    # Store species value
+    self.species = species
 
-  problems = {
-    'blank_line':     [],
-    'wrong_species':  [],
-    'unknown_strain': [],
-    'duplicates':     [],
-  }
+    # Store uniqueness values
+    self._force_unique      = force_unique
+    self._force_unique_msgs = force_unique_msgs
+
+    # Get the list of all valid strain names for this species
+    # Pull from strain names & isotype names, to allow for isotypes with no strain of the same name
+    self._valid_names_species = {
+      *query_strains(all_strain_names=True, species=species.name),
+      *get_distinct_isotypes(species=species.name),
+    }
+
+    # Get the list of all valid strain names for all species
+    # Used to provide more informative error messages
+    self._valid_names_all = {
+      *query_strains(all_strain_names=True),
+      *get_distinct_isotypes(),
+    }
+
+    # Dict to track the first line each strain occurs on
+    # Used to ensure strains are unique, if applicable
+    self._strain_line_numbers = {}
+
+    self._problems = {
+      'blank_line':     [],
+      'wrong_species':  [],
+      'unknown_strain': [],
+      'duplicates':     [],
+    }
 
 
-  def check_strain_list(problem_list, err_messages):
+  @classmethod
+  def check_strain_list(cls, problem_list, err_messages):
     '''
       Given a list of lines that matched a specific error condition, collate the unique set of strains and create an error message.
       If the list is empty, no error will be thrown.
@@ -220,31 +265,29 @@ def validate_strain(species, force_unique=False, force_unique_msgs=None):
 
 
   # Validator function run at the end of the file
-  def func_final():
-    nonlocal force_unique_msgs
-    nonlocal problems
+  def finish(self):
 
     # Wrong species #
-    check_strain_list(problems['wrong_species'], {
-      'single':  lambda x: f'The strain { x } is not a valid strain for { species.short_name } in our current dataset. Please enter a valid { species.short_name } strain.',
-      'few':     lambda x: f'The strains { x } are not valid strains for { species.short_name } in our current dataset. Please enter valid { species.short_name } strains.',
-      'default': lambda x: f'Multiple strains are not valid for { species.short_name } in our current dataset.',
+    self.check_strain_list(self._problems['wrong_species'], {
+      'single':  lambda x: f'The strain { x } is not a valid strain for { self.species.short_name } in our current dataset. Please enter a valid { self.species.short_name } strain.',
+      'few':     lambda x: f'The strains { x } are not valid strains for { self.species.short_name } in our current dataset. Please enter valid { self.species.short_name } strains.',
+      'default': lambda x: f'Multiple strains are not valid for { self.species.short_name } in our current dataset.',
     })
 
     # Blank lines #
-    if len(problems['blank_line']) > 0:
-      line_str = join_commas_and([ p['line'] for p in problems['blank_line'] ])
+    if len(self._problems['blank_line']) > 0:
+      line_str = join_commas_and([ p['line'] for p in self._problems['blank_line'] ])
       raise DataFormatError(f'Strain values cannot be blank. Please check line(s) { line_str } to ensure valid strains have been entered.')
 
     # Unknown strains #
-    check_strain_list(problems['unknown_strain'], {
+    self.check_strain_list(self._problems['unknown_strain'], {
       'single':  lambda x: f'The strain { x } is not a valid strain name in our current dataset. Please enter valid strain names.',
       'few':     lambda x: f'The strains { x } are not valid strain names in our current dataset. Please enter valid strain names.',
       'default': lambda x: f'Multiple strains are not valid in our current dataset.',
     })
 
     # Duplicate strains #
-    check_strain_list(problems['duplicates'], force_unique_msgs or {
+    self.check_strain_list(self._problems['duplicates'], self._force_unique_msgs or {
       'single':  lambda x: f'Multiple lines contain duplicate values for the strain { x }. Please ensure that only one unique value exists per strain.',
       'default': lambda x: f'Multiple lines contain duplicate values for the same strain. Please ensure that only one unique value exists per strain.',
     })
@@ -252,53 +295,51 @@ def validate_strain(species, force_unique=False, force_unique_msgs=None):
 
   # Validator function run on each individual line
   # Keeps track of all errors, which are then run at the end by func_final
-  def func_step(header, value, line):
-    nonlocal force_unique
-    nonlocal strain_line_numbers, valid_names_species, valid_names_all, problems
+  def read_line(self, header, value, line):
 
     # Check for blank strain
     if value == '':
-      problems['blank_line'].append({'value': value, 'line': line})
+      self._problems['blank_line'].append({'value': value, 'line': line})
 
     # Check if strain is valid for the desired species
-    elif value not in valid_names_species:
-      if value in valid_names_all:
-        problems['wrong_species'].append({'value': value, 'line': line})
+    elif value not in self._valid_names_species:
+      if value in self._valid_names_all:
+        self._problems['wrong_species'].append({'value': value, 'line': line})
       else:
-        problems['unknown_strain'].append({'value': value, 'line': line})
+        self._problems['unknown_strain'].append({'value': value, 'line': line})
 
     # If desired, keep track of list of strains and throw an error if a duplicate is found
-    if force_unique:
-      if value in strain_line_numbers:
-        problems['duplicates'].append({'value': value, 'line': line})
+    if self._force_unique:
+      if value in self._strain_line_numbers:
+        self._problems['duplicates'].append({'value': value, 'line': line})
       else:
-        strain_line_numbers[value] = line
-
-
-  # Return both validator functions
-  return {
-    'step': func_step,
-    'final': func_final,
-  }
+        self._strain_line_numbers[value] = line
 
 
 
-# Check that all values in a column have the same trait name
-def validate_trait():
+#
+# Traits
+#
 
-  # Initialize var to track the single valid trait name
-  trait_name = None
+class TraitValidator(ColumnValidator):
+  '''
+    Check that all values in a column have the same trait name
+  '''
 
-  # Define the validator function
-  def func(header, value, line):
-    nonlocal trait_name
+  def __init__(self, trait_name: str = None):
+    # Initialize var to track the single valid trait name
+    self._trait_name = trait_name
+
+
+  def read_line(self, header, value, line):
+    '''
+      Ensure all lines contain the same trait value.
+    '''
 
     # If no trait name has been encountered yet, save the first value
-    if trait_name is None:
-      trait_name = value
+    if self._trait_name is None:
+      self._trait_name = value
 
     # If the trait name has been set, ensure this line matches it
-    elif value != trait_name:
+    elif value != self._trait_name:
       raise DataFormatError(f'The data contain multiple unique trait name values. Only one trait name may be tested per file.', line)
-
-  return { 'step': func }

--- a/src/pkg/caendr/caendr/utils/data.py
+++ b/src/pkg/caendr/caendr/utils/data.py
@@ -113,6 +113,13 @@ def get_file_format(file_ext, valid_formats=None):
   return None
 
 
+def get_delimiter_from_filepath(filepath=None, valid_file_extensions=None):
+  valid_file_extensions = valid_file_extensions or {'csv'}
+  if filepath:
+    file_format = get_file_format(filepath[-3:], valid_formats=valid_file_extensions)
+    if file_format:
+      return file_format['sep']
+
 
 
 def join_with_final(text, sep='', final=None, final_if_two=None):


### PR DESCRIPTION
Cleans up the validation logic.
- The `step` and `final` functions are now class methods instead of optional returns on an arbitrary dict, which standardized the logic for running the validators
- The column header validation is moved into the new `ColumnValidator` objects, which cleans up the syntax for `validate_file` (now takes a list of `ColumnValidators` rather than a list of semi-arbitrary dicts)