### PR TITLE
Hotfix: JS import for flashing message manually

### DIFF
--- a/src/modules/site-v2/templates/_scripts/utils.js
+++ b/src/modules/site-v2/templates/_scripts/utils.js
@@ -145,7 +145,9 @@ function flash_message(message, full_msg_link=null, full_msg_body=null) {
   document.getElementById('alert-container').appendChild(node);
 
   // Italicize species name(s) in the alert message
+  {%- if species_list %}
   {%- for species in species_list.values() %}
   node.innerHTML = node.innerHTML.replace('{{ species.short_name }}', '<i>{{ species.short_name }}</i>')
   {%- endfor %}
+  {%- endif %}
 }


### PR DESCRIPTION
Checks for `species_list` variable before trying to access.

I don't think this is broken in later branches (somehow), but it appeared for me on the Dataset Release page(s) in the current dev branch.