### PR TITLE
Better error checking if Dataset Release files don't exist

### DIFF
--- a/src/modules/site-v2/base/utils/markdown.py
+++ b/src/modules/site-v2/base/utils/markdown.py
@@ -20,7 +20,7 @@ def render_markdown(filename, directory="base/static/content/markdown"):
 
 
 def render_ext_markdown(url: str, ignore_err=False, backup_text=None):
-  if url is None:
+  if not url:
     return Markup(markdown.markdown(backup_text or ''))
 
   template = ''

--- a/src/modules/site-v2/templates/data/v2.html
+++ b/src/modules/site-v2/templates/data/v2.html
@@ -48,7 +48,7 @@
                     <div class="row">
                         <div class="col-6">
                             <h2>Release Notes</h2>
-                            <p>{{ render_ext_markdown(files and files.get('release_notes'), ignore_err=true, backup_text="*Release notes are not available at this time.*") }}</p>
+                            <p>{{ render_ext_markdown((files or {}).get('release_notes'), ignore_err=true, backup_text="*Release notes are not available at this time.*") }}</p>
                         </div>
                         <div class="col-6">
                             <div class="card">
@@ -57,7 +57,7 @@
                                 </div>
                                 <div class="card-body">
                                     <p class="card-text">
-                                        {{ render_ext_markdown(files and files.get('summary'), ignore_err=true, backup_text="*Release summary is not available at this time.*") }}
+                                        {{ render_ext_markdown((files or {}).get('summary'), ignore_err=true, backup_text="*Release summary is not available at this time.*") }}
                                     </p>
                                 </div>
                             </div>


### PR DESCRIPTION
Specifically, if the `DatasetRelease` entity exists but *none* of the files exist, would crash trying to render Markdown files.

The existing `files and ...` guards work when `files is None` (render fallback) or `files` is an object with fields (i.e. some files exist, but maybe not the desired MD file).

The problem was, if `files` is an empty object `{}`, then `{} and {}.get(...)` will evaluate to `{}` (it takes precedence over the `None` result in the second argument slot).  This would pass an empty object to `render_ext_markdown` as the `url`, which in turn wasn't properly caught (since that function would only guard against `None`).

Changes:
- Better guard for files: `files or {}` will fallback to an empty dict, then `.get` will retrieve `None` since no fields exist.
- Better guard for empty "url"s: now checks against `bool` conversion, which catches `None` as well as `''` and `{}`.