### PR TITLE
Phenotype Report Labels

### DIFF
--- a/src/modules/site-v2/base/static/js/plot.js
+++ b/src/modules/site-v2/base/static/js/plot.js
@@ -160,6 +160,7 @@ function render_scatterplot_histograms(container_selector, data, config={}) {
 
     // Create a template function for the tooltip
     // By default, show label & value for each axis
+    const tooltip_id       = config['tooltip_id']       || null;
     const tooltip_template = config['tooltip_template'] || ((d, labels) => `
       <p class="tooltip-body">${labels[0]}: ${d[0]}</p>
       <p class="tooltip-body">${labels[1]}: ${d[1]}</p>
@@ -227,6 +228,11 @@ function render_scatterplot_histograms(container_selector, data, config={}) {
       .append("div")
       .attr("class", "tooltip")
       .style("opacity", 0);
+
+    // If an ID is provided for the tooltip, add it
+    if (tooltip_id) {
+      tooltip.attr("id", tooltip_id);
+    }
 
     // Add mouseover listener for individual dots
     dots.on('mouseover', function(d) {
@@ -389,6 +395,7 @@ function render_ranked_barplot(container_selector, data, config={}) {
 
   // Create a template function for the tooltip
   // By default, show label & value for each axis
+  const tooltip_id       = config['tooltip_id']       || null;
   const tooltip_template = config['tooltip_template'] || ((d) => `
     <p class="tooltip-body">${d[1]}: ${d[0]}</p>
   `);
@@ -452,6 +459,11 @@ function render_ranked_barplot(container_selector, data, config={}) {
     .append("div")
     .attr("class", "tooltip")
     .style("opacity", 0);
+
+  // If an ID is provided for the tooltip, add it
+  if (tooltip_id) {
+    tooltip.attr("id", tooltip_id);
+  }
 
   // Add mouseover listener for individual bars -- show the tooltip
   bars.on('mouseover', function(d) {

--- a/src/modules/site-v2/base/static/js/plot.js
+++ b/src/modules/site-v2/base/static/js/plot.js
@@ -157,6 +157,8 @@ function render_scatterplot_histograms(container_selector, data, config={}) {
     const circle_radius = config['circle_radius'] || 4;
     const fill_color    = config['fill_color']    || 'black';
     const stroke_color  = config['stroke_color']  || 'none';
+    const opacity       = config['opacity']       || 0;
+    const opacity_hover = config['opacity_hover'] || 0;
 
     // Create a template function for the tooltip
     // By default, show label & value for each axis
@@ -220,8 +222,9 @@ function render_scatterplot_histograms(container_selector, data, config={}) {
       .attr("cx", d => x(d[0]) )
       .attr("cy", d => y(d[1]) )
       .attr("r", circle_radius)
-      .style('fill',   fill_color)
-      .style('stroke', stroke_color);
+      .style('fill',    fill_color)
+      .style('stroke',  stroke_color)
+      .style('opacity', opacity)
 
     // Create tooltip for data point mouseover
     const tooltip = d3.select(container_selector)
@@ -238,7 +241,7 @@ function render_scatterplot_histograms(container_selector, data, config={}) {
     dots.on('mouseover', function(d) {
 
       // Select the dot and grow its radius
-      d3.select(this).attr('r', circle_radius + 2);
+      d3.select(this).attr('r', circle_radius + 2).style('opacity', opacity_hover);
       
       // Show the tooltip
       tooltip.html(tooltip_template(d, [ config['x_label'], config['y_label'] ]))
@@ -253,7 +256,7 @@ function render_scatterplot_histograms(container_selector, data, config={}) {
     dots.on('mouseout', function() {
 
       // Select the dot and restore its original radius
-      d3.select(this).attr('r', circle_radius);
+      d3.select(this).attr('r', circle_radius).style('opacity', opacity);
 
       // Hide the tooltip
       tooltip.transition()

--- a/src/modules/site-v2/base/static/js/plot.js
+++ b/src/modules/site-v2/base/static/js/plot.js
@@ -161,8 +161,8 @@ function render_scatterplot_histograms(container_selector, data, config={}) {
     // Create a template function for the tooltip
     // By default, show label & value for each axis
     const tooltip_template = config['tooltip_template'] || ((d, labels) => `
-      <p>${labels[0]}: ${d[0]}</p>
-      <p>${labels[1]}: ${d[1]}</p>
+      <p class="tooltip-body">${labels[0]}: ${d[0]}</p>
+      <p class="tooltip-body">${labels[1]}: ${d[1]}</p>
     `);
 
     // Create the SVG object for the full graphic (scatterplot + histograms + margins)
@@ -390,7 +390,7 @@ function render_ranked_barplot(container_selector, data, config={}) {
   // Create a template function for the tooltip
   // By default, show label & value for each axis
   const tooltip_template = config['tooltip_template'] || ((d) => `
-    <p>${d[1]}: ${d[0]}</p>
+    <p class="tooltip-body">${d[1]}: ${d[0]}</p>
   `);
 
   // Sort data

--- a/src/modules/site-v2/templates/tools/phenotype_database/report.html
+++ b/src/modules/site-v2/templates/tools/phenotype_database/report.html
@@ -19,6 +19,10 @@
     .tooltip p {
         margin-bottom: 0;
     }
+
+    .tooltip .tooltip-head {}
+
+    .tooltip .tooltip-body {}
 </style>
 
 {% endblock %}
@@ -109,8 +113,8 @@ try {
         bins_per_tick: 4,
         x_label:       trait_label,
         tooltip_template: (d, labels) => `
-            <p><b>Strain: ${d[2]}</b></p>
-            <p>${labels[0]}: ${d[0]}</p>
+            <p class="tooltip-head"><b>Strain: ${d[2]}</b></p>
+            <p class="tooltip-body">${labels[0]}: ${d[0]}</p>
         `,
     });
 } catch (err) {
@@ -124,8 +128,8 @@ try {
         fill_color:    '#0719BC',
         y_label:       trait_label,
         tooltip_template: (d) => `
-            <p>Strain: ${d[1]}</p>
-            <p>Value: ${d[0]}</p>
+            <p class="tooltip-head">Strain: ${d[1]}</p>
+            <p class="tooltip-body">Value: ${d[0]}</p>
         `,
     });
 } catch (err) {
@@ -164,9 +168,9 @@ try {
         x_label:       `Mean centered ${trait_label_1}`,
         y_label:       `Mean centered ${trait_label_2}`,
         tooltip_template: (d, labels) => `
-            <p><b>Strain: ${d[2]}</b></p>
-            <p>${labels[0]}: ${d[0]}</p>
-            <p>${labels[1]}: ${d[1]}</p>
+            <p class="tooltip-head"><b>Strain: ${d[2]}</b></p>
+            <p class="tooltip-body">${labels[0]} = ${d[0]}</p>
+            <p class="tooltip-body">${labels[1]} = ${d[1]}</p>
         `,
     });
 } catch (err) {

--- a/src/modules/site-v2/templates/tools/phenotype_database/report.html
+++ b/src/modules/site-v2/templates/tools/phenotype_database/report.html
@@ -130,8 +130,8 @@ try {
         y_label:       trait_label,
         tooltip_id:    'tooltip-single-barplot',
         tooltip_template: (d) => `
-            <p class="tooltip-head">Strain: ${d[1]}</p>
-            <p class="tooltip-body">Value: ${d[0]}</p>
+            <p class="tooltip-head"><b>${d[1]}</b></p>
+            <p class="tooltip-body">Value = ${d[0]}</p>
         `,
     });
 } catch (err) {
@@ -173,9 +173,9 @@ try {
         y_label:       `Mean centered ${trait_label_2}`,
         tooltip_id:    'tooltip-double-scatterplot',
         tooltip_template: (d, labels) => `
-            <p class="tooltip-head"><b>Strain: ${d[2]}</b></p>
-            <p class="tooltip-body">${labels[0]} = ${d[0]}</p>
-            <p class="tooltip-body">${labels[1]} = ${d[1]}</p>
+            <p class="tooltip-head"><b>${d[2]}</b></p>
+            <p class="tooltip-body">x = ${d[0]}</p>
+            <p class="tooltip-body">y = ${d[1]}</p>
         `,
     });
 } catch (err) {

--- a/src/modules/site-v2/templates/tools/phenotype_database/report.html
+++ b/src/modules/site-v2/templates/tools/phenotype_database/report.html
@@ -112,6 +112,7 @@ try {
         fill_color:    '#0719BC',
         bins_per_tick: 4,
         x_label:       trait_label,
+        tooltip_id:    'tooltip-single-histogram',
         tooltip_template: (d, labels) => `
             <p class="tooltip-head"><b>Strain: ${d[2]}</b></p>
             <p class="tooltip-body">${labels[0]}: ${d[0]}</p>
@@ -127,6 +128,7 @@ try {
         height:        400,
         fill_color:    '#0719BC',
         y_label:       trait_label,
+        tooltip_id:    'tooltip-single-barplot',
         tooltip_template: (d) => `
             <p class="tooltip-head">Strain: ${d[1]}</p>
             <p class="tooltip-body">Value: ${d[0]}</p>
@@ -167,6 +169,7 @@ try {
         bins_per_tick: 2,
         x_label:       `Mean centered ${trait_label_1}`,
         y_label:       `Mean centered ${trait_label_2}`,
+        tooltip_id:    'tooltip-double-scatterplot',
         tooltip_template: (d, labels) => `
             <p class="tooltip-head"><b>Strain: ${d[2]}</b></p>
             <p class="tooltip-body">${labels[0]} = ${d[0]}</p>

--- a/src/modules/site-v2/templates/tools/phenotype_database/report.html
+++ b/src/modules/site-v2/templates/tools/phenotype_database/report.html
@@ -166,6 +166,8 @@ try {
         width:         800,
         height:        800,
         fill_color:    '#0719BC',
+        opacity:       0.75,
+        opacity_hover: 1,
         bins_per_tick: 2,
         x_label:       `Mean centered ${trait_label_1}`,
         y_label:       `Mean centered ${trait_label_2}`,

--- a/src/modules/site-v2/templates/tools/phenotype_database/report.html
+++ b/src/modules/site-v2/templates/tools/phenotype_database/report.html
@@ -13,8 +13,11 @@
         height: auto;
         border: 1px solid black;
         pointer-events: none;
-        line-height: 1px;
         background-color: white;
+    }
+
+    .tooltip p {
+        margin-bottom: 0;
     }
 </style>
 

--- a/src/modules/site-v2/templates/tools/phenotype_database/report.html
+++ b/src/modules/site-v2/templates/tools/phenotype_database/report.html
@@ -22,7 +22,9 @@
 
     .tooltip .tooltip-head {}
 
-    .tooltip .tooltip-body {}
+    .tooltip .tooltip-body {
+        padding: 0 4px;
+    }
 </style>
 
 {% endblock %}


### PR DESCRIPTION
Start implementing better tooltips in line with 1/11/24 meeting.  For styling, I've added config variables that control the elements we might want to change (opacity, etc), to make it easier on @natalieroman in case we want to tweak the tooltips later.

Sample tooltips, as they'll look after this PR:
<img width="164" alt="Double-trait Scatterplot Tooltip Example" src="https://github.com/AndersenLab/CAENDR/assets/22177771/53e5a141-9e34-45f4-ae5a-8efb5f80dc69">
<img width="164" alt="Single-trait Ranked Barplot Tooltip Example" src="https://github.com/AndersenLab/CAENDR/assets/22177771/9604ceee-f0d3-4120-87f0-76ff0b8590bb">


Highlights:
- Updates labels
  - Replaces trait names with `x = ...` and `y = ...`
  - Removes the word `Strain: ` and just prints the strain name directly.  We can definitely revert this change.
- Adds config parameters for scatterplot dot opacity
  - `opacity` controls the default opacity
  - `opacity_hover` controls the opacity on mouseover
  - For now, I've set these to 0.75 and 1, mostly to demo how the variables work. We'll definitely want to tweak these values.
- Cleans up spacing
  - Text is now vertically centered :)
  - Adds a bit of padding to the body elements.  We can definitely revert this change / tweak this padding.


---

Note: If you'd like to look at the tooltip for styling without having to mouse over a dot every time, the following HTML will replicate the example tooltips shown above:
```
<div class="tooltip" style="position: relative; opacity: 1; width: fit-content;">
    <p class="tooltip-head"><b>NIC258</b></p>
    <p class="tooltip-body">x = 8.540704986943403</p>
    <p class="tooltip-body">y = 1.675780911513509</p>
</div>

<div class="tooltip" style="position: relative; opacity: 1; width: fit-content;">
    <p class="tooltip-head"><b>ECA2583</b></p>
    <p class="tooltip-body">Value = -35.84013654</p>
</div>
```