### PR TITLE
Hotfix: Viewing reports for non-admin users

### DIFF
--- a/src/pkg/caendr/caendr/models/datastore/user.py
+++ b/src/pkg/caendr/caendr/models/datastore/user.py
@@ -94,6 +94,18 @@ class User(Entity):
 
 
 
+  ## Equality ##
+
+  def __eq__(self, other):
+    '''
+      Two `User` objects are considered equal if their datastore IDs match.
+    '''
+    if not isinstance(other, User):
+      return False
+    return self.name == other.name
+
+
+
   ## Other ##
 
   def reports(self):


### PR DESCRIPTION
If two `User` objects represent the same datastore entry, they are now explicitly considered equal.

This caused a bug for non-admin users trying to access one of their reports -- since the equality check would fail, they would be denied access.

Using a new test account, I've confirmed this bug did not make it to production.