### PR TITLE
Fix DB Stats Page

### DIFF
--- a/src/modules/site-v2/base/views/admin/etl.py
+++ b/src/modules/site-v2/base/views/admin/etl.py
@@ -40,14 +40,23 @@ def admin_etl_op():
 @admin_etl_op_bp.route('/stats', methods=["GET"])
 @admin_required()
 def admin_etl_stats():
-  alt_parent_breadcrumb = {"title": "Admin", "url": url_for('admin.admin')}
-  title = 'ETL Stats'
+
+  # Check db status
   status, message = health_database_status()
   logger.debug(f"DB Status is {status} {message}")
   logger.debug("ETL Stats loading...")
+
+  # Get db stats
   stats = get_all_db_stats()
   logger.info(stats)
-  return render_template('admin/etl/stats.html', **locals())
+
+  return render_template('admin/etl/stats.html', **{
+    'title': 'ETL Stats',
+    'alt_parent_breadcrumb': {"title": "Admin", "url": url_for('admin.admin')},
+
+    # Stats
+    'stats': stats,
+  })
 
 
 

--- a/src/pkg/caendr/caendr/models/sql/__init__.py
+++ b/src/pkg/caendr/caendr/models/sql/__init__.py
@@ -7,3 +7,12 @@ from .wormbase_gene import WormbaseGene
 from .wormbase_gene_summary import WormbaseGeneSummary
 from .phenotype import PhenotypeDatabase
 from .phenotype_metadata import PhenotypeMetadata
+
+ALL_SQL_TABLES = [
+  Strain,
+  WormbaseGene,
+  WormbaseGeneSummary,
+  StrainAnnotatedVariant,
+  PhenotypeDatabase,
+  PhenotypeMetadata,
+]

--- a/src/pkg/caendr/caendr/services/database_operation.py
+++ b/src/pkg/caendr/caendr/services/database_operation.py
@@ -15,12 +15,27 @@ MODULE_DB_OPERATIONS_CONTAINER_VERSION = get_env_var('MODULE_DB_OPERATIONS_CONTA
 
 
 
+#
+# Retrieving ETL Op Entities
+#
+
 # TODO: Should this return DatabaseOperation entity objects?
 def get_all_db_ops(keys_only=False, order=None, placeholder=True):
   logger.debug(f'get_all_db_ops(keys_only={keys_only}, order={order})')
   ds_entities = query_ds_entities(DatabaseOperation.kind, keys_only=keys_only, order=order)
   # logger.debug(ds_entities)
   return ds_entities
+
+def get_etl_op(op_id, keys_only=False, order=None, placeholder=True):
+  logger.debug(f'get_etl_op(op_id={op_id}, keys_only={keys_only}, order={order})')
+  op = get_ds_entity(DatabaseOperation.kind, op_id)
+  logger.debug(op)
+  return op
+
+
+#
+# Computing SQL Table Stats
+#
 
 def get_count(q):
     count_q = q.statement.with_only_columns([func.count()]).order_by(None)
@@ -45,11 +60,10 @@ def get_all_db_stats():
   stats = [ [model.__tablename__, get_table_count_safe(model)] for model in ALL_SQL_TABLES ]
   return stats
 
-def get_etl_op(op_id, keys_only=False, order=None, placeholder=True):
-  logger.debug(f'get_etl_op(op_id={op_id}, keys_only={keys_only}, order={order})')
-  op = get_ds_entity(DatabaseOperation.kind, op_id)
-  logger.debug(op)
-  return op
+
+#
+# Db Op Forms
+#
 
 def get_db_op_form_options(): 
   return [ (op_type.value, DbOp.get_title(op_type)) for op_type in DbOp ]

--- a/src/pkg/caendr/caendr/services/database_operation.py
+++ b/src/pkg/caendr/caendr/services/database_operation.py
@@ -75,8 +75,11 @@ def get_table_count_safe(model):
 
 
 def get_all_db_stats():
-  stats = [ [model.__tablename__, get_table_count_safe(model)] for model in ALL_SQL_TABLES ]
-  return stats
+  '''
+    Count the rows in each table, and return all results.
+    Returns `None` for any table that threw an error when trying to count the rows.
+  '''
+  return [ [model.__tablename__, get_table_count_safe(model)] for model in ALL_SQL_TABLES ]
 
 
 #

--- a/src/pkg/caendr/caendr/services/database_operation.py
+++ b/src/pkg/caendr/caendr/services/database_operation.py
@@ -3,7 +3,7 @@ from caendr.services.logger import logger
 from sqlalchemy import func 
 
 from caendr.models.datastore import DatabaseOperation
-from caendr.models.sql import DbOp, Homolog, StrainAnnotatedVariant, Strain, WormbaseGene, WormbaseGeneSummary
+from caendr.models.sql import DbOp, ALL_SQL_TABLES
 from caendr.services.tool_versions import GCR_REPO_NAME
 from caendr.services.cloud.datastore import get_ds_entity, query_ds_entities
 from caendr.utils.data import unique_id
@@ -35,42 +35,8 @@ def get_table_count(model):
   return result[0]
 
 def get_all_db_stats():
-  # d = {
-  #   'Homolog': get_count(Homolog.query),
-  #   'StrainAnnotatedVariant': get_count(StrainAnnotatedVariant.query),
-  #   'Strain': get_count(Strain.query),
-  #   'WormbaseGene': get_count(WormbaseGene.query),
-  #   'WormbaseGeneSummary': get_count(WormbaseGeneSummary.query)
-  # }
-
-  models = [Homolog, StrainAnnotatedVariant, Strain, WormbaseGene, WormbaseGeneSummary]
-
-  stats = [ [model.__tablename__, get_table_count(model)] for model in models]
-
+  stats = [ [model.__tablename__, get_table_count(model)] for model in ALL_SQL_TABLES ]
   return stats
-
-  
-
-  homolog_count = get_count(Homolog.query)
-  logger.info(f'homolog_count: {homolog_count}')
-  strain_annotated_variant_count = get_count(StrainAnnotatedVariant.query)
-  logger.info(f'strain_annotated_variant_count: {strain_annotated_variant_count}')
-  wormbase_gene_count = get_count(WormbaseGene.query)
-  logger.info(f'wormbase_gene_count: {wormbase_gene_count}')
-  wormbase_gene_summary_count = get_count(WormbaseGeneSummary.query)
-  logger.info(f'wormbase_gene_summary_count: {wormbase_gene_summary_count}')
-  strain_count = get_count(Strain.query)
-  logger.info(f'strain_count: {strain_count}')
-  
-  d = {
-    'Homolog': homolog_count,
-    'StrainAnnotatedVariant': strain_annotated_variant_count,
-    'Strain': strain_count,
-    'WormbaseGene': wormbase_gene_count,
-    'WormbaseGeneSummary': wormbase_gene_summary_count
-  }
-  return d
-
 
 def get_etl_op(op_id, keys_only=False, order=None, placeholder=True):
   logger.debug(f'get_etl_op(op_id={op_id}, keys_only={keys_only}, order={order})')

--- a/src/pkg/caendr/caendr/services/database_operation.py
+++ b/src/pkg/caendr/caendr/services/database_operation.py
@@ -1,14 +1,12 @@
-import os
-from caendr.services.logger import logger
 from sqlalchemy import func 
 
-from caendr.models.datastore import DatabaseOperation
-from caendr.models.sql import DbOp, ALL_SQL_TABLES
-from caendr.services.tool_versions import GCR_REPO_NAME
-from caendr.services.cloud.datastore import get_ds_entity, query_ds_entities
+from caendr.services.logger           import logger
+from caendr.utils.env                 import get_env_var
+
+from caendr.models.datastore          import DatabaseOperation
+from caendr.models.sql                import DbOp, ALL_SQL_TABLES
+from caendr.services.cloud.datastore  import get_ds_entity, query_ds_entities
 from caendr.services.cloud.postgresql import rollback_on_error
-from caendr.utils.data import unique_id
-from caendr.utils.env import get_env_var
 
 
 MODULE_DB_OPERATIONS_BUCKET_NAME       = get_env_var('MODULE_DB_OPERATIONS_BUCKET_NAME')

--- a/src/pkg/caendr/caendr/services/database_operation.py
+++ b/src/pkg/caendr/caendr/services/database_operation.py
@@ -38,7 +38,7 @@ def get_etl_op(op_id, keys_only=False, order=None, placeholder=True):
 #
 
 @rollback_on_error
-def get_table_count(model) -> int:
+def count_table_rows(model) -> int:
   '''
     Count the number of rows in a SQL table.
 
@@ -58,7 +58,7 @@ def get_table_count(model) -> int:
 #   result = session.execute(query).fetchone()
 #   return result[0]
 
-def get_table_count_safe(model):
+def count_table_rows_safe(model):
   '''
     Count the number of rows in a SQL table.
     If any error is thrown, logs as a warning and returns `None` instead.
@@ -66,7 +66,7 @@ def get_table_count_safe(model):
 
   # Try getting the count directly, handling any SQL errors
   try:
-    return get_table_count(model)
+    return count_table_rows(model)
 
   # Log errors and return None
   except Exception as ex:
@@ -79,7 +79,7 @@ def get_all_db_stats():
     Count the rows in each table, and return all results.
     Returns `None` for any table that threw an error when trying to count the rows.
   '''
-  return [ [model.__tablename__, get_table_count_safe(model)] for model in ALL_SQL_TABLES ]
+  return [ [model.__tablename__, count_table_rows_safe(model)] for model in ALL_SQL_TABLES ]
 
 
 #

--- a/src/pkg/caendr/caendr/services/database_operation.py
+++ b/src/pkg/caendr/caendr/services/database_operation.py
@@ -6,6 +6,7 @@ from caendr.models.datastore import DatabaseOperation
 from caendr.models.sql import DbOp, ALL_SQL_TABLES
 from caendr.services.tool_versions import GCR_REPO_NAME
 from caendr.services.cloud.datastore import get_ds_entity, query_ds_entities
+from caendr.services.cloud.postgresql import rollback_on_error
 from caendr.utils.data import unique_id
 from caendr.utils.env import get_env_var
 
@@ -28,14 +29,22 @@ def get_count(q):
     count = q.session.execute(count_q).scalar()
     return count
 
+@rollback_on_error
 def get_table_count(model):
   session = model.query.session
   query = f"SELECT reltuples AS estimate FROM pg_class where relname = '{model.__tablename__}';"
   result = session.execute(query).fetchone()
   return result[0]
 
+def get_table_count_safe(model):
+  try:
+    return get_table_count(model)
+  except Exception as ex:
+    logger.warning(f'Error getting count for table {model}: {ex}')
+    return None
+
 def get_all_db_stats():
-  stats = [ [model.__tablename__, get_table_count(model)] for model in ALL_SQL_TABLES ]
+  stats = [ [model.__tablename__, get_table_count_safe(model)] for model in ALL_SQL_TABLES ]
   return stats
 
 def get_etl_op(op_id, keys_only=False, order=None, placeholder=True):


### PR DESCRIPTION
Currently breaking in QA/dev because there's no error handling for the deprecated Homologs table. (Not breaking in prod, where that table still exists.)