### PR TITLE
Indel Finder "Rerun" Option

### DIFF
--- a/src/modules/site-v2/base/views/tools/genetic_mapping.py
+++ b/src/modules/site-v2/base/views/tools/genetic_mapping.py
@@ -97,6 +97,7 @@ def list_results():
     # Page info
     'title': ('All' if show_all else 'My') + ' Genetic Mappings',
     'tool_alt_parent_breadcrumb': {"title": "Tools", "url": url_for('tools.tools')},
+    'user_is_admin': user_is_admin(),
 
     # Tool info
     'tool_name': 'genetic_mapping',

--- a/src/modules/site-v2/base/views/tools/heritability_calculator.py
+++ b/src/modules/site-v2/base/views/tools/heritability_calculator.py
@@ -98,6 +98,7 @@ def list_results():
     'title': ('All' if show_all else 'My') + ' Heritability Results',
     'subtitle': 'Report List',
     'alt_parent_breadcrumb': {"title": "Tools", "url": url_for('tools.tools')},
+    'user_is_admin': user_is_admin(),
 
     # Tool info
     'tool_name': 'heritability_calculator',

--- a/src/modules/site-v2/base/views/tools/pairwise_indel_finder.py
+++ b/src/modules/site-v2/base/views/tools/pairwise_indel_finder.py
@@ -3,7 +3,7 @@ import re
 from caendr.services.logger import logger
 from flask import Response, Blueprint, render_template, request, url_for, jsonify, redirect, flash, abort
 
-from base.forms import PairwiseIndelForm
+from base.forms import PairwiseIndelForm, EmptyForm
 from base.utils.auth import jwt_required, admin_required, get_current_user, user_is_admin
 from base.utils.tools import list_reports, try_submit
 from base.utils.view_decorators import parse_job_id, validate_form
@@ -145,9 +145,11 @@ def list_results():
     # Page info
     'title': ('All' if show_all else 'My') + ' Primer Reports',
     'tool_alt_parent_breadcrumb': { "title": "Tools", "url": url_for('tools.tools'), },
+    'form': EmptyForm(),
 
     # User info
     'user':  user,
+    'user_is_admin': user_is_admin(),
 
     # Tool info
     'tool_name': 'pairwise_indel_finder',
@@ -161,6 +163,7 @@ def list_results():
     # Table info
     'species_list': Species.all(),
     'items': list_reports(IndelPrimerReport, None if show_all else user, filter_errs),
+    'rerunnable': True,
   })
 
 
@@ -193,6 +196,19 @@ def submit(form_data, no_cache=False):
 
   # Return the response
   return jsonify( response ), code
+
+
+
+@pairwise_indel_finder_bp.route('/resubmit/<report_id>', methods=['POST'])
+@admin_required()
+@parse_job_id(IndelFinderPipeline, fetch=False)
+def resubmit(job: IndelFinderPipeline):
+  job.schedule(no_cache=True)
+  return jsonify({
+    'ready':     job.is_finished(),
+    'data_hash': job.report.data_hash,
+    'id':        job.report.id,
+  })
 
 
 

--- a/src/modules/site-v2/base/views/tools/pairwise_indel_finder.py
+++ b/src/modules/site-v2/base/views/tools/pairwise_indel_finder.py
@@ -10,7 +10,7 @@ from base.utils.view_decorators import parse_job_id, validate_form
 
 from caendr.models.datastore.browser_track import BrowserTrackDefault
 from caendr.models.datastore import Species, IndelPrimerReport, DatasetRelease
-from caendr.models.error import NotFoundError, NonUniqueEntity
+from caendr.models.error import NotFoundError, NonUniqueEntity, JobAlreadyScheduledError
 from caendr.models.job_pipeline import IndelFinderPipeline
 from caendr.services.dataset_release import get_dataset_release
 from caendr.services.cloud.storage import BlobURISchema
@@ -203,12 +203,29 @@ def submit(form_data, no_cache=False):
 @admin_required()
 @parse_job_id(IndelFinderPipeline, fetch=False)
 def resubmit(job: IndelFinderPipeline):
-  job.schedule(no_cache=True)
-  return jsonify({
-    'ready':     job.is_finished(),
-    'data_hash': job.report.data_hash,
-    'id':        job.report.id,
-  })
+
+  # Try scheduling the job again
+  try:
+    job.schedule(no_cache=True)
+    return jsonify({
+      'ready':     job.is_finished(),
+      'data_hash': job.report.data_hash,
+      'id':        job.report.id,
+    })
+
+  # If this job is currently running, abort
+  except JobAlreadyScheduledError as ex:
+    return jsonify({
+      'message': 'This job is already running.',
+    }), 400
+
+  # Display any other errors to the (admin) user
+  except Exception as ex:
+    return jsonify({
+      'message': 'There was a problem resubmitting this job. Please try again later.',
+      'full_msg_link': 'See details.',
+      'full_msg_body': getattr(ex, 'message', str(ex)),
+    }), 500
 
 
 

--- a/src/modules/site-v2/base/views/tools/phenotype_database.py
+++ b/src/modules/site-v2/base/views/tools/phenotype_database.py
@@ -173,6 +173,7 @@ def list_results():
 
     # User info
     'user':  user,
+    'user_is_admin': user_is_admin(),
 
     # Tool info
     'tool_name': 'phenotype_database',

--- a/src/modules/site-v2/templates/tools/report-list.html
+++ b/src/modules/site-v2/templates/tools/report-list.html
@@ -72,6 +72,9 @@ span.bi {
         {{ render_dataTable_result_list_header('Date',   extra_classes='ordering') }}
         {% if all_results %}
         {{ render_dataTable_result_list_header('Owner',  extra_classes='ordering') }}
+        {%- if user_is_admin and rerunnable %}
+        {{ render_dataTable_result_list_header('Rerun',  extra_classes='ordering') }}
+        {%- endif %}
         {% endif %}
       </tr>
     </thead>
@@ -96,6 +99,15 @@ span.bi {
 
             {% if all_results %}
               <td class="data-owner">{{ item.get_display_name() }}</td>
+              {%- if user_is_admin and rerunnable %}
+              <td class="data-rerun optionsToolbar">
+                {%- if item.status == JobStatus.ERROR %}
+                <button role="button" class="btn btn-link" onclick="resubmit(this, '{{ item.name }}')">
+                  <i class="bi bi-arrow-right-circle-fill" aria-hidden="true"></i> Rerun
+                </a>
+                {%- endif %}
+              </td>
+              {%- endif %}
             {% endif %}
           </tr>
         {% endif %}
@@ -110,6 +122,7 @@ span.bi {
 {% endblock %}
 
 {% block script %}
+{% from "_scripts/submit-job.js" import ajax_setup %}
 <script>
 
   const status_colors = {
@@ -121,6 +134,11 @@ span.bi {
   }
       
   $(document).ready(function(){
+
+    // Set headers for AJAX requests
+    {%- if form %}
+    {{ ajax_setup(form.csrf_token._value()) }}
+    {%- endif %}
 
     dTable = $('#result-table').DataTable( {
       paging: true,
@@ -136,14 +154,17 @@ span.bi {
         { "sWidth": ({{column.width}} * 36) + '%' },
       {%- endfor %}
         {
-          "sWidth": "10%",
+          "sWidth": "6%",
           "createdCell": function (td, cellData, rowData, row, col) {
             $(td).addClass( 'bg-' + status_colors[cellData.toUpperCase()] + ' bg-opacity-25' )
           }
         },
-        { "sWidth": "22%" },
+        { "sWidth": "20%" },
       {%- if all_results %}
-        { "sWidth": "22%" },
+        { "sWidth": "18%" },
+        {%- if user_is_admin and rerunnable %}
+        { "sWidth": "10%" },
+        {%- endif %}
       {%- endif %}
       ],
       dom: "tipr",
@@ -164,6 +185,23 @@ span.bi {
       location.reload();
       console.log("reload the page!")
     }
+
+
+  {%- if rerunnable and user_is_admin %}
+  function resubmit(el, job_id) {
+    el.classList.add('disabled');
+
+    $.ajax({
+      url:  "{{ url_for(tool_name + '.resubmit', report_id='JOB_ID') }}".replace("JOB_ID", job_id),
+      type: "POST",
+    })
+      .done((result) => {
+        el.classList.remove('disabled');
+        el.innerHTML = `<i class="bi bi-check-circle-fill" aria-hidden="true">`;
+        el.onclick = null;
+      })
+  }
+  {%- endif %}
 
 </script>
 {% endblock %}

--- a/src/modules/site-v2/templates/tools/report-list.html
+++ b/src/modules/site-v2/templates/tools/report-list.html
@@ -124,6 +124,8 @@ span.bi {
 {% block script %}
 {% from "_scripts/submit-job.js" import ajax_setup %}
 <script>
+  {% include '_scripts/utils.js' %} {#/* defines: flashErrorResponse */#}
+
 
   const status_colors = {
     "{{ JobStatus.ERROR }}"     : "danger",
@@ -199,6 +201,10 @@ span.bi {
         el.classList.remove('disabled');
         el.innerHTML = `<i class="bi bi-check-circle-fill" aria-hidden="true">`;
         el.onclick = null;
+      })
+      .fail((error) => {
+        el.classList.remove('disabled');
+        flashErrorResponse(error.responseJSON, 'There was a problem resubmitting this job. Please try again later.');
       })
   }
   {%- endif %}


### PR DESCRIPTION
- On admin-only "View All Reports" page, add an optional column to re-run a job that ended in an error
- Enable Rerun column for Indel Finder (with an admin-only "resubmit" endpoint)

In the future, if an Indel Finder job fails for a user, we'll now be able to easily re-run their report once we've fixed the container / site.

TODO: Should we enable this for the other tools? Should discuss the way their data is stored.  Indel Finder lends itself better to this, since the user doesn't provide any upload file, they just choose one of our pre-defined regions.