### PR TITLE
Update yield number from 1000 to 100

### DIFF
--- a/src/modules/site-v2/base/views/tools/phenotype_database.py
+++ b/src/modules/site-v2/base/views/tools/phenotype_database.py
@@ -92,7 +92,7 @@ def download_csv():
   def generate():
     yield file_format['sep'].join(columns) + '\n'
     try:
-      for row in traits.yield_per(1000):
+      for row in traits.yield_per(100):
         row = [getattr(row, column) for column in columns]
         yield file_format['sep'].join(map(str, row)) + '\n'
     except Exception as ex:


### PR DESCRIPTION
Updated yield number for query execution, as there were 'request timed out' warnings in the production site. Already tested out with `yield_per(100)` -> all rows have been successfully written to CSV.